### PR TITLE
[220130] Refactor tags and apply design to input

### DIFF
--- a/css/cover.css
+++ b/css/cover.css
@@ -56,3 +56,12 @@ body {
 #app {
   height: 100%;
 }
+
+.btn-click {
+  border: none;
+  padding: 8px;
+  margin: 4px;
+  border-radius: 4px;
+  background-color: #1890ff;
+  color: #fff;
+}

--- a/src/components/PostCategoryTagsForm.jsx
+++ b/src/components/PostCategoryTagsForm.jsx
@@ -1,37 +1,31 @@
-import styled from '@emotion/styled';
-
 import {
   categories,
 } from '../data/hashTags';
 
-const HashtagBox = styled.div({
-  textAlign: 'left',
-  margin: '8px 0',
-  '& button': {
-    border: 'none',
-    padding: '8px',
-    margin: '4px',
-    borderRadius: '4px',
-  },
-  '& button:focus': {
-    backgroundColor: '#000',
-    color: '#fff',
-  },
-});
+import HashtagBox from '../style/HashtagBox';
 
 export default function PostCategoryTagsForm({ onClickTag }) {
+  function handleClick(event, categoryId) {
+    const { target } = event;
+    if (!target.className) {
+      target.className = 'btn-click'
+    } else {
+      target.classList.remove('btn-click')
+    }
+    onClickTag(categoryId);
+  }
+
   return (
     <>
       <HashtagBox>
         <p>무엇을 드셨나요?</p>
         {categories.map((category) => (
-          <button
+          <input
             type='button'
             key={category.id}
-            onClick={() => onClickTag(category.id)}
-          >
-            {category.name}
-          </button>
+            onClick={(event) => handleClick(event, category.id)}
+            value={category.name}
+          />
         ))}
       </HashtagBox>
     </>

--- a/src/components/PostConditionTagsForm.jsx
+++ b/src/components/PostConditionTagsForm.jsx
@@ -1,37 +1,31 @@
-import styled from '@emotion/styled';
-
 import {
   conditions,
 } from '../data/hashTags';
 
-const HashtagBox = styled.div({
-  textAlign: 'left',
-  margin: '8px 0',
-  '& button': {
-    border: 'none',
-    padding: '8px',
-    margin: '4px',
-    borderRadius: '4px',
-  },
-  '& button:focus': {
-    backgroundColor: '#000',
-    color: '#fff',
-  },
-});
+import HashtagBox from '../style/HashtagBox';
 
 export default function PostConditionTagsForm({ onClickTag }) {
+  function handleClick(event, conditionId) {
+    const { target } = event;
+    if (!target.className) {
+      target.className = 'btn-click'
+    } else {
+      target.classList.remove('btn-click')
+    }
+    onClickTag(conditionId);
+  }
+
   return (
     <>
       <HashtagBox>
         <p>어떤 상황인가요?</p>
         {conditions.map((condition) => (
-          <button
+          <input
             type='button'
             key={condition.id}
-            onClick={() => onClickTag(condition.id)}
-          >
-            {condition.name}
-          </button>
+            onClick={(event) => handleClick(event, condition.id)}
+            value={condition.name}
+          />
         ))}
       </HashtagBox>
     </>

--- a/src/components/PostInputForm.jsx
+++ b/src/components/PostInputForm.jsx
@@ -5,7 +5,13 @@ const InputBox = styled.div({
   alignItems: 'center',
   margin: '12px 0',
   '& label': {
-    marginRight: '8px',
+    marginRight: '12px',
+  },
+  '& input': {
+    background: 'transparent',
+    border: 'none',
+    borderBottom: '1px solid #fff',
+    color: '#fff',
   },
 });
 

--- a/src/components/PostRegionTagsForm.jsx
+++ b/src/components/PostRegionTagsForm.jsx
@@ -1,37 +1,31 @@
-import styled from '@emotion/styled';
-
 import {
   regions,
 } from '../data/hashTags';
 
-const HashtagBox = styled.div({
-  textAlign: 'left',
-  margin: '8px 0',
-  '& button': {
-    border: 'none',
-    padding: '8px',
-    margin: '4px',
-    borderRadius: '4px',
-  },
-  '& button:focus': {
-    backgroundColor: '#000',
-    color: '#fff',
-  },
-});
+import HashtagBox from '../style/HashtagBox';
 
 export default function PostRegionTagsForm({ onClickTag }) {
+  function handleClick(event, regionId) {
+    const { target } = event;
+    if (!target.className) {
+      target.className = 'btn-click'
+    } else {
+      target.classList.remove('btn-click')
+    }
+    onClickTag(regionId);
+  }
+
   return (
     <>
       <HashtagBox>
         <p>어디인가요?</p>
         {regions.map((region) => (
-          <button
+          <input
             type='button'
             key={region.id}
-            onClick={() => onClickTag(region.id)}
-          >
-            {region.name}
-          </button>
+            onClick={(event) => handleClick(event, region.id)}
+            value={region.name}
+          />
         ))}
       </HashtagBox>
     </>

--- a/src/containers/PostCategoryTagsContainer.jsx
+++ b/src/containers/PostCategoryTagsContainer.jsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled';
-
 import { useSelector, useDispatch } from 'react-redux';
 
 import PostCategoryTagsForm from '../components/PostCategoryTagsForm';
@@ -8,12 +6,7 @@ import {
   selectCategoryTag,
 } from '../actions';
 
-const PostFormBox = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'flex-start',
-});
+import PostFormBox from '../style/PostFormBox';
 
 export default function PostFormContainer() {
   // ToDoDelete 상태 잘 바뀌는지 확인용

--- a/src/containers/PostConditionTagsContainer.jsx
+++ b/src/containers/PostConditionTagsContainer.jsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled';
-
 import { useSelector, useDispatch } from 'react-redux';
 
 import PostConditionTagsForm from '../components/PostConditionTagsForm';
@@ -8,12 +6,7 @@ import {
   selectConditionTag,
 } from '../actions';
 
-const PostFormBox = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'flex-start',
-});
+import PostFormBox from '../style/PostFormBox';
 
 export default function PostFormContainer() {
   // ToDoDelete 상태 잘 바뀌는지 확인용

--- a/src/containers/PostInputContainer.jsx
+++ b/src/containers/PostInputContainer.jsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled';
-
 import { useSelector, useDispatch } from 'react-redux';
 
 import PostInputForm from '../components/PostInputForm';
@@ -8,12 +6,7 @@ import {
   setRestaurantName,
 } from '../actions';
 
-const PostFormBox = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'flex-start',
-});
+import PostFormBox from '../style/PostFormBox';
 
 export default function PostInputContainer() {
   // ToDoDelete 상태 잘 바뀌는지 확인용

--- a/src/containers/PostRegionTagsContainer.jsx
+++ b/src/containers/PostRegionTagsContainer.jsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled';
-
 import { useSelector, useDispatch } from 'react-redux';
 
 import PostRegionTagsForm from '../components/PostRegionTagsForm';
@@ -8,12 +6,7 @@ import {
   selectRegionTag,
 } from '../actions';
 
-const PostFormBox = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'flex-start',
-});
+import PostFormBox from '../style/PostFormBox';
 
 export default function PostFormContainer() {
   // ToDoDelete 상태 잘 바뀌는지 확인용

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -8,9 +8,6 @@ const initialState = {
   restaurant: {
     name: '',
   },
-  conditions,
-  regions,
-  categories,
 };
 
 const reducers = {

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -3,6 +3,8 @@ import reducer from './reducer';
 import {
   setRestaurantName,
   selectConditionTag,
+  selectRegionTag,
+  selectCategoryTag,
 } from './actions';
 
 describe('reducer', () => {
@@ -37,6 +39,40 @@ describe('reducer', () => {
 
       expect(state.conditions).toEqual({
         id: 1, name: '#혼밥',
+      });
+    });
+  });
+
+  describe('selectRegionTag action', () => {
+    it('finds clicked tag with selectedId', () => {
+      const initialState = {
+        regions: [
+          { id: 1, name: '#서울 송파구' },
+          { id: 2, name: '#서울 강남구' },
+        ],
+      }
+
+      const state = reducer(initialState, selectRegionTag(1));
+
+      expect(state.regions).toEqual({
+        id: 1, name: '#서울 송파구',
+      });
+    });
+  });
+
+  describe('selectCategoryTag action', () => {
+    it('finds clicked tag with selectedId', () => {
+      const initialState = {
+        categories: [
+          { id: 1, name: '#면' },
+          { id: 2, name: '#밥' },
+        ],
+      }
+
+      const state = reducer(initialState, selectCategoryTag(1));
+
+      expect(state.categories).toEqual({
+        id: 1, name: '#면',
       });
     });
   });

--- a/src/style/HashtagBox.js
+++ b/src/style/HashtagBox.js
@@ -1,0 +1,14 @@
+import styled from '@emotion/styled';
+
+const HashtagBox = styled.div({
+  textAlign: 'left',
+  margin: '8px 0',
+  '& input': {
+    border: 'none',
+    padding: '8px',
+    margin: '4px',
+    borderRadius: '4px',
+  },
+});
+
+export default HashtagBox;

--- a/src/style/PostFormBox.js
+++ b/src/style/PostFormBox.js
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+const PostFormBox = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'flex-start',
+});
+
+export default PostFormBox;


### PR DESCRIPTION
## 게시물포스팅페이지 구현
### Progressing
사용자는 해시태그를 직접 선택할 수 있습니다.

> - [x] 인풋 디자인 적용
> - [x] 버튼 클릭시 클래스 추가해서 색변경, 바뀐 색 유지
> - [x] 버튼 다시 클릭하면 클래스 이름 삭제됨, 원래 색으로 돌아감

### ToDoNext
선택(색변경)은 다중이 가능하지만,
스토어에 들어오는 정보는 가장 마지막에 클릭한 버튼만 들어옴
버튼 복수 선택 안되게 하기