### PR TITLE
[220210] Click hash tag, then JSON array will be sorted

### DIFF
--- a/__mocks__/react-redux.js
+++ b/__mocks__/react-redux.js
@@ -1,7 +1,3 @@
 export const useDispatch = jest.fn();
 
 export const useSelector = jest.fn();
-
-export const find = jest.fn();
-
-export const filter = jest.fn();

--- a/__mocks__/react-redux.js
+++ b/__mocks__/react-redux.js
@@ -1,3 +1,7 @@
 export const useDispatch = jest.fn();
 
 export const useSelector = jest.fn();
+
+export const find = jest.fn();
+
+export const filter = jest.fn();

--- a/assets/json/restaurants.json
+++ b/assets/json/restaurants.json
@@ -7,136 +7,136 @@
     "category": "순대국밥"
   },
   {
-    "name": "별미곱창",
+    "name": "청와옥",
     "id": "11",
-    "condition": "회식",
+    "condition": "과음한 다음 날",
     "region": "서울 송파구",
-    "category": "곱창, 막창"
+    "category": "순대국밥"
   },
   {
-    "name": "뱃놈",
+    "name": "행운동조개",
     "id": "12",
-    "condition": "친구들이랑",
-    "region": "서울 광진구",
+    "condition": "퇴근길",
+    "region": "서울 송파구",
     "category": "조개"
   },
   {
-    "name": "봉쥬르스고이",
+    "name": "청와옥",
     "id": "13",
-    "condition": "소개팅",
-    "region": "서울 용산구",
-    "category": "일식"
-  },
-  {
-    "name": "진지아",
-    "id": "14",
-    "condition": "데이트",
+    "condition": "과음한 다음 날",
     "region": "서울 송파구",
-    "category": "중화요리"
+    "category": "순대국밥"
   },
   {
-    "name": "어쩔티비",
+    "name": "봉쥬르스고이",
+    "id": "14",
+    "condition": "퇴근길",
+    "region": "서울 송파구",
+    "category": "일본식라면"
+  },
+  {
+    "name": "청와옥",
     "id": "15",
     "condition": "퇴근길",
     "region": "서울 마포구",
     "category": "일본식라면"
   },
   {
-    "name": "저쩔티비",
+    "name": "봉쥬르스고이",
     "id": "16",
     "condition": "주말",
     "region": "서울 강남구",
-    "category": "한식"
+    "category": "한우"
   },
   {
     "name": "수와래",
     "id": "17",
-    "condition": "데이트",
-    "region": "서울 종로구",
-    "category": "스테이크, 립"
+    "condition": "주말",
+    "region": "서울 강남구",
+    "category": "조개"
   },
   {
-    "name": "한솥",
+    "name": "행운동조개",
     "id": "18",
-    "condition": "혼밥",
-    "region": "서울 광진구",
-    "category": "도시락"
+    "condition": "주말",
+    "region": "서울 강남구",
+    "category": "조개"
   },
   {
-    "name": "크크루삥뽕",
+    "name": "행운동조개",
     "id": "19",
     "condition": "주말",
     "region": "서울 성동구",
-    "category": "참치회"
+    "category": "조개"
   },
   {
     "name": "행운동조개",
     "id": "20",
     "condition": "데이트",
-    "region": "서울 관악구",
-    "category": "조개"
+    "region": "서울 성동구",
+    "category": "일본식라면"
   },
   {
-    "name": "핵인싸공방",
+    "name": "합정광안리",
     "id": "21",
-    "condition": "축하하고싶은 날",
-    "region": "서울 강남구",
+    "condition": "데이트",
+    "region": "서울 성동구",
     "category": "회"
   },
   {
     "name": "합정광안리",
     "id": "22",
     "condition": "친구들이랑",
-    "region": "서울 마포구",
+    "region": "서울 성동구",
     "category": "회"
   },
   {
-    "name": "마틸다",
+    "name": "합정광안리",
     "id": "23",
-    "condition": "우울할 때",
-    "region": "서울 종로구",
+    "condition": "친구들이랑",
+    "region": "서울 성동구",
     "category": "한우"
   },
   {
-    "name": "휘뚜루마뚜루",
+    "name": "합정광안리",
     "id": "24",
-    "condition": "회식",
-    "region": "서울 강남구",
-    "category": "한식"
+    "condition": "친구들이랑",
+    "region": "서울 성동구",
+    "category": "한우"
   },
   {
-    "name": "솔로지옥",
+    "name": "합정광안리",
     "id": "25",
     "condition": "데이트",
-    "region": "서울 용산구",
-    "category": "일식"
+    "region": "서울 성동구",
+    "category": "일본식라면"
   },
   {
-    "name": "시고르자브종",
+    "name": "수와래",
     "id": "26",
     "condition": "혼밥",
     "region": "서울 송파구",
     "category": "일본식라면"
   },
   {
-    "name": "찐맛집",
+    "name": "수와래",
     "id": "27",
-    "condition": "축하하고싶은 날",
-    "region": "서울 관악구",
+    "condition": "데이트",
+    "region": "서울 성동구",
     "category": "한우"
   },
   {
-    "name": "찐찐맛집",
+    "name": "수와래",
     "id": "28",
-    "condition": "소개팅",
+    "condition": "데이트",
     "region": "서울 성동구",
     "category": "참치회"
   },
   {
-    "name": "찐찐찐맛집",
+    "name": "수와래",
     "id": "29",
     "condition": "주말",
-    "region": "서울 종로구",
-    "category": "스테이크, 립"
+    "region": "서울 강남구",
+    "category": "참치회"
   }
 ]

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -19,15 +19,21 @@ describe('App', () => {
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      selectedCondition: { id: 1, name: '혼밥', color: 'blue' },
-      selectedRegion: { id: 1, name: '서울 송파구', color: 'blue' },
-      selectedCategory: { id: 1, name: '면', color: 'blue' },
-      getCondition: 
-      { id: 10, name: '청와옥', condition: '과음한 다음 날', color: 'blue' },
-      getRegion: 
-      { id: 10, name: '청와옥', region: '서울 송파구', color: 'blue' },
-      getCategory: 
-      { id: 10, name: '청와옥', category: '순대국밥', color: 'blue' },
+      sortedConditions: [
+        { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue' }
+      ],
+      sortedRegions: [
+        { id: 1, name: '청와옥', condition: '서울 송파구', color: 'blue' }
+      ],
+      sortedCategories: [
+        { id: 1, name: '청와옥', condition: '순대국밥', color: 'blue' }
+      ],
+      selectedCondition: 
+      { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue'},
+      selectedRegion: 
+      { id: 1, name: '청와옥', condition: '서울 송파구', color: 'blue'},
+      selectedCategory: 
+      { id: 1, name: '청와옥', condition: '순대국밥', color: 'blue'},
       restaurant: { name: '멘카야' },
     }));
   });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -23,17 +23,17 @@ describe('App', () => {
         { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue' }
       ],
       sortedRegions: [
-        { id: 1, name: '청와옥', condition: '서울 송파구', color: 'blue' }
+        { id: 1, name: '청와옥', region: '서울 송파구', color: 'blue' }
       ],
       sortedCategories: [
-        { id: 1, name: '청와옥', condition: '순대국밥', color: 'blue' }
+        { id: 1, name: '청와옥', category: '순대국밥', color: 'blue' }
       ],
       selectedCondition: 
       { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue'},
       selectedRegion: 
-      { id: 1, name: '청와옥', condition: '서울 송파구', color: 'blue'},
+      { id: 1, name: '청와옥', region: '서울 송파구', color: 'blue'},
       selectedCategory: 
-      { id: 1, name: '청와옥', condition: '순대국밥', color: 'blue'},
+      { id: 1, name: '청와옥', category: '순대국밥', color: 'blue'},
       restaurant: { name: '멘카야' },
     }));
   });

--- a/src/actions.js
+++ b/src/actions.js
@@ -47,23 +47,23 @@ export function selectCategoryTag(selectedId) {
   }
 }
 
-export function getConditionTag(conditionObj) {
+export function sortByCondition(selectedName) {
   return {
-    type: 'getConditionTag',
-    payload: { conditionObj },
+    type: 'sortByCondition',
+    payload: { selectedName },
   }
 }
 
-export function getRegionTag(regionObj) {
+export function sortByRegion(selectedName) {
   return {
-    type: 'getRegionTag',
-    payload: { regionObj },
+    type: 'sortByRegion',
+    payload: { selectedName },
   }
 }
 
-export function getCategoryTag(categoryObj) {
+export function sortByCategory(selectedName) {
   return {
-    type: 'getCategoryTag',
-    payload: { categoryObj },
+    type: 'sortByCategory',
+    payload: { selectedName },
   }
 }

--- a/src/components/PostCategoryTagsForm.jsx
+++ b/src/components/PostCategoryTagsForm.jsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+// ToDo delete
 import {
   categories,
 } from '../data/hashTags';

--- a/src/components/PostConditionTagsForm.jsx
+++ b/src/components/PostConditionTagsForm.jsx
@@ -1,3 +1,4 @@
+// ToDo delete
 import {
   conditions,
 } from '../data/hashTags';

--- a/src/components/PostRegionTagsForm.jsx
+++ b/src/components/PostRegionTagsForm.jsx
@@ -1,3 +1,4 @@
+// ToDo delete
 import {
   regions,
 } from '../data/hashTags';

--- a/src/containers/HomeCategoryTagsContainer.jsx
+++ b/src/containers/HomeCategoryTagsContainer.jsx
@@ -43,7 +43,6 @@ export default function HomeCategoryTagsContainer({ categoriesArr }) {
       state : state.selectedCategory
   ));
   const {color} = selectedCategory;
-  console.log(selectedCategory);
 
   const sortedCategories = useSelector((state) => ({
     sortedCategories: state.sortedCategories,

--- a/src/containers/HomeCategoryTagsContainer.jsx
+++ b/src/containers/HomeCategoryTagsContainer.jsx
@@ -1,12 +1,15 @@
 import styled from '@emotion/styled';
 
+import uniqBy from 'lodash.uniqby';
+
 import { useEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
   setCategories,
-  getCategoryTag,
+  sortByCategory,
+  selectCategoryTag,
 } from '../actions';
 
 const TagsBox = styled.div({
@@ -22,32 +25,41 @@ const Hashtags = styled.button({
 });
 
 export default function HomeCategoryTagsContainer({ categoriesArr }) {
+  const sortCategories = uniqBy(categoriesArr, 'category');
+
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(setCategories(categoriesArr));
   }, []);
 
-  function handleClickTag(categoryObj) {
-    dispatch(getCategoryTag(categoryObj));
+  function handleClickTag(selectedName, selectedId) {
+    dispatch(sortByCategory(selectedName));
+    dispatch(selectCategoryTag(selectedId));
   }
 
-  const getCategory = useSelector((state) => (
-    state.getCategory === null ?
-      state : state.getCategory
+  const selectedCategory = useSelector((state) => (
+    state.selectedCategory === null ?
+      state : state.selectedCategory
   ));
-  const {color} = getCategory;
+  const {color} = selectedCategory;
+  console.log(selectedCategory);
+
+  const sortedCategories = useSelector((state) => ({
+    sortedCategories: state.sortedCategories,
+  }));
+  console.log(sortedCategories);
 
   return (
     <TagsBox>
       <p>무엇을 드시고 싶으세요?</p>
-      {categoriesArr.map((obj) => (
+      {sortCategories.map((obj) => (
         <Hashtags
           type="button"
           key={obj.id}
-          onClick={() => handleClickTag(obj)}
+          onClick={() => handleClickTag(obj.category, obj.id)}
           className={
-            obj.id === getCategory.id ?
+            obj.id === selectedCategory.id ?
               color : ""
           }
         >

--- a/src/containers/HomeCategoryTagsContainer.test.jsx
+++ b/src/containers/HomeCategoryTagsContainer.test.jsx
@@ -13,8 +13,9 @@ import HomeCategoryTagsContainer from './HomeCategoryTagsContainer';
 jest.mock('react-redux');
 
 describe('HomeCategoryTagsContainer', () => {
+  // 최초 JSON 데이터
   const categoriesArr = [
-    { id: 10, name: '청와옥', category: '순대국밥' },
+    { id: 1, name: '청와옥', category: '순대국밥' },
   ]
 
   const dispatch = jest.fn();
@@ -25,8 +26,8 @@ describe('HomeCategoryTagsContainer', () => {
     useDispatch.mockImplementation(() => dispatch);
   
     useSelector.mockImplementation((selector) => selector({
-      getCategory: 
-      { id: 10, name: '청와옥', category: '순대국밥', color: 'blue' },
+      selectedCategory: 
+      { id: 1, name: '청와옥', category: '순대국밥', color: 'blue' },
     }));
   });
 
@@ -52,17 +53,16 @@ describe('HomeCategoryTagsContainer', () => {
   });
 
   context('when click "#순대국밥" tag', () => {
-    const categoryObj = 
-    { id: 10, name: '청와옥', category: '순대국밥' };
+    const selectedName = '순대국밥';
 
-    it('calls dispatch with action : getCategoryTag', () => {
+    it('calls dispatch with action : sortByCategory', () => {
       const { getByText } = renderHomeCategoryTagsContainer();
 
       fireEvent.click(getByText('#순대국밥'));
 
       expect(dispatch).toBeCalledWith({
-        type: 'getCategoryTag',
-        payload: { categoryObj },
+        type: 'sortByCategory',
+        payload: { selectedName },
       })
     });
   });

--- a/src/containers/HomeConditionTagsContainer.jsx
+++ b/src/containers/HomeConditionTagsContainer.jsx
@@ -1,12 +1,15 @@
 import styled from '@emotion/styled';
 
+import uniqBy from 'lodash.uniqby';
+
 import { useEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
   setConditions,
-  getConditionTag,
+  sortByCondition,
+  selectConditionTag,
 } from '../actions';
 
 const TagsBox = styled.div({
@@ -22,32 +25,41 @@ const Hashtags = styled.button({
 });
 
 export default function HomeConditionTagsContainer({ conditionsArr }) {
+  const sortConditions = uniqBy(conditionsArr, 'condition');
+
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(setConditions(conditionsArr));
   }, []);
 
-  function handleClickTag(conditionObj) {
-    dispatch(getConditionTag(conditionObj));
+  function handleClickTag(selectedName, selectedId) {
+    dispatch(sortByCondition(selectedName));
+    dispatch(selectConditionTag(selectedId));
   }
 
-  const getCondition = useSelector((state) => (
-    state.getCondition === null ?
-      state : state.getCondition
+  const selectedCondition = useSelector((state) => (
+    state.selectedCondition === null ?
+      state : state.selectedCondition
   ));
-  const {color} = getCondition;
+  const {color} = selectedCondition;
+  console.log(selectedCondition);
+
+  const sortedConditions = useSelector((state) => ({
+    sortedConditions: state.sortedConditions,
+  }));
+  console.log(sortedConditions);
 
   return (
     <TagsBox>
       <p>어떤 상황인가요?</p>
-      {conditionsArr.map((obj) => (
+      {sortConditions.map((obj) => (
         <Hashtags
           type="button"
           key={obj.id}
-          onClick={() => handleClickTag(obj)}
+          onClick={() => handleClickTag(obj.condition, obj.id)}
           className={
-            obj.id === getCondition.id ?
+            obj.id === selectedCondition.id ?
               color : ""
           }
         >

--- a/src/containers/HomeConditionTagsContainer.jsx
+++ b/src/containers/HomeConditionTagsContainer.jsx
@@ -43,7 +43,6 @@ export default function HomeConditionTagsContainer({ conditionsArr }) {
       state : state.selectedCondition
   ));
   const {color} = selectedCondition;
-  console.log(selectedCondition);
 
   const sortedConditions = useSelector((state) => ({
     sortedConditions: state.sortedConditions,

--- a/src/containers/HomeConditionTagsContainer.test.jsx
+++ b/src/containers/HomeConditionTagsContainer.test.jsx
@@ -13,8 +13,9 @@ import HomeConditionTagsContainer from './HomeConditionTagsContainer';
 jest.mock('react-redux');
 
 describe('HomeConditionTagsContainer', () => {
+  // 최초 JSON 데이터
   const conditionsArr = [
-    { id: 10, name: '청와옥', condition: '과음한 다음 날' },
+    { id: 1, name: '청와옥', condition: '과음한 다음 날' },
   ]
 
   const dispatch = jest.fn();
@@ -25,8 +26,8 @@ describe('HomeConditionTagsContainer', () => {
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      getCondition: 
-      { id: 10, name: '청와옥', condition: '과음한 다음 날', color: 'blue' },
+      selectedCondition: 
+      { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue'},
     }));
   });
 
@@ -42,7 +43,7 @@ describe('HomeConditionTagsContainer', () => {
     it('calls dispatch with action : setConditions', () => {
       const { container } = renderHomeConditionTagsContainer();
 
-      expect(container).toHaveTextContent('과음한 다음 날');
+      expect(container).toHaveTextContent('#과음한 다음 날');
 
       expect(dispatch).toBeCalledWith({
         type: 'setConditions',
@@ -52,17 +53,16 @@ describe('HomeConditionTagsContainer', () => {
   });
 
   context('when click "#과음한 다음 날" tag', () => {
-    const conditionObj = 
-    { id: 10, name: '청와옥', condition: '과음한 다음 날' };
+    const selectedName = '과음한 다음 날';
 
-    it('calls dispatch with action : getConditionTag', () => {
+    it('calls dispatch with action : sortByCondition', () => {
       const { getByText } = renderHomeConditionTagsContainer();
 
       fireEvent.click(getByText('#과음한 다음 날'));
 
       expect(dispatch).toBeCalledWith({
-        type: 'getConditionTag',
-        payload: { conditionObj },
+        type: 'sortByCondition',
+        payload: { selectedName },
       })
     });
   });

--- a/src/containers/HomeRegionTagsContainer.jsx
+++ b/src/containers/HomeRegionTagsContainer.jsx
@@ -1,12 +1,15 @@
 import styled from '@emotion/styled';
 
+import uniqBy from 'lodash.uniqby';
+
 import { useEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
   setRegions,
-  getRegionTag,
+  sortByRegion,
+  selectRegionTag,
 } from '../actions';
 
 const TagsBox = styled.div({
@@ -22,32 +25,41 @@ const Hashtags = styled.button({
 });
 
 export default function HomeRegionTagsContainer({ regionsArr }) {
+  const sortRegions = uniqBy(regionsArr, 'region');
+
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(setRegions(regionsArr));
   }, []);
 
-  function handleClickTag(regionObj) {
-    dispatch(getRegionTag(regionObj));
+  function handleClickTag(selectedName, selectedId) {
+    dispatch(sortByRegion(selectedName));
+    dispatch(selectRegionTag(selectedId));
   }
 
-  const getRegion = useSelector((state) => (
-    state.getRegion === null ?
-      state : state.getRegion
+  const selectedRegion = useSelector((state) => (
+    state.selectedRegion === null ?
+      state : state.selectedRegion
   ));
-  const {color} = getRegion;
+  const {color} = selectedRegion;
+  console.log(selectedRegion);
+
+  const sortedRegions = useSelector((state) => ({
+    sortedRegions: state.sortedRegions,
+  }));
+  console.log(sortedRegions);
 
   return (
     <TagsBox>
       <p>어디로 가고 싶나요?</p>
-      {regionsArr.map((obj) => (
+      {sortRegions.map((obj) => (
         <Hashtags
           type="button"
           key={obj.id}
-          onClick={() => handleClickTag(obj)}
+          onClick={() => handleClickTag(obj.region, obj.id)}
           className={
-            obj.id === getRegion.id ?
+            obj.id === selectedRegion.id ?
               color : ""
           }
         >

--- a/src/containers/HomeRegionTagsContainer.jsx
+++ b/src/containers/HomeRegionTagsContainer.jsx
@@ -43,7 +43,6 @@ export default function HomeRegionTagsContainer({ regionsArr }) {
       state : state.selectedRegion
   ));
   const {color} = selectedRegion;
-  console.log(selectedRegion);
 
   const sortedRegions = useSelector((state) => ({
     sortedRegions: state.sortedRegions,

--- a/src/containers/HomeRegionTagsContainer.test.jsx
+++ b/src/containers/HomeRegionTagsContainer.test.jsx
@@ -13,8 +13,9 @@ import HomeRegionTagsContainer from './HomeRegionTagsContainer';
 jest.mock('react-redux');
 
 describe('HomeRegionTagsContainer', () => {
+  // 최초 JSON 데이터
   const regionsArr = [
-    { id: 10, name: '청와옥', region: '서울 송파구' },
+    { id: 1, name: '청와옥', region: '서울 송파구' },
   ]
 
   const dispatch = jest.fn();
@@ -25,8 +26,8 @@ describe('HomeRegionTagsContainer', () => {
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      getRegion: 
-      { id: 10, name: '청와옥', region: '서울 송파구', color: 'blue' },
+      selectedRegion: 
+      { id: 1, name: '청와옥', region: '서울 송파구', color: 'blue'},
     }));
   });
 
@@ -52,17 +53,29 @@ describe('HomeRegionTagsContainer', () => {
   });
 
   context('when click "#서울 송파구" tag', () => {
-    const regionObj = 
-    { id: 10, name: '청와옥', region: '서울 송파구' };
+    it('calls dispatch with action : sortByRegion', () => {
+      const selectedName = '서울 송파구';
 
-    it('calls dispatch with action : getRegionTag', () => {
       const { getByText } = renderHomeRegionTagsContainer();
 
       fireEvent.click(getByText('#서울 송파구'));
 
       expect(dispatch).toBeCalledWith({
-        type: 'getRegionTag',
-        payload: { regionObj },
+        type: 'sortByRegion',
+        payload: { selectedName },
+      })
+    });
+
+    it('calls dispatch with action : selectRegionTag', () => {
+      const selectedId = 1;
+
+      const { getByText } = renderHomeRegionTagsContainer();
+
+      fireEvent.click(getByText('#서울 송파구'));
+
+      expect(dispatch).toBeCalledWith({
+        type: 'selectRegionTag',
+        payload: { selectedId },
       })
     });
   });

--- a/src/data (1)/hashTags.js
+++ b/src/data (1)/hashTags.js
@@ -1,0 +1,37 @@
+const conditions = [
+  //누구랑?
+  { id: 1, name: '#혼밥' },
+  { id: 2, name: '#데이트' },
+  { id: 3, name: '#친구들이랑' },
+  //어떨 때?
+  { id: 4, name: '#스트레스 받은 날' },
+  { id: 5, name: '#행복한 날' },
+  { id: 6, name: '#축하하고싶은 날' },
+  //언제?
+  { id: 7, name: '#퇴근길' },
+  { id: 8, name: '#주말' },
+];
+
+const regions = [
+  { id: 1, name: '#서울 송파구' },
+  { id: 2, name: '#서울 강남구' },
+  { id: 3, name: '#서울 종로구' },
+  { id: 4, name: '#서울 용산구' },
+  { id: 5, name: '#서울 마포구' },
+  { id: 6, name: '#서울 성동구' },
+];
+
+const categories = [
+  { id: 1, name: '#면' },
+  { id: 2, name: '#밥' },
+  { id: 3, name: '#고기' },
+  { id: 4, name: '#해산물' },
+  { id: 5, name: '#패스트푸드' },
+  { id: 6, name: '#샐러드' },
+];
+
+export {
+  conditions,
+  regions,
+  categories,
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -4,8 +4,6 @@ import HomeCategoryTagsContainer from '../containers/HomeCategoryTagsContainer';
 
 import styled from '@emotion/styled';
 
-import uniqBy from 'lodash.uniqby';
-
 import {
   Link,
 } from 'react-router-dom';
@@ -31,20 +29,17 @@ const PostLayout = styled.h1({
 });
 
 export default function HomePage({ restaurants }) {
-  const sortCoditions = uniqBy(restaurants, 'condition');
-  const conditionsArr = sortCoditions.map((obj) => {
+  const conditionsArr = restaurants.map((obj) => {
     const { name, id, condition } = obj;
     return { id: id, name: name, condition: condition };
   });
 
-  const sortRegions = uniqBy(restaurants, 'region');
-  const regionsArr = sortRegions.map((obj) => {
+  const regionsArr = restaurants.map((obj) => {
     const { name, id, region } = obj;
     return { id: id, name: name, region: region };
   });
 
-  const sortCategories = uniqBy(restaurants, 'category');
-  const categoriesArr = sortCategories.map((obj) => {
+  const categoriesArr = restaurants.map((obj) => {
     const { name, id, category } = obj;
     return { id: id, name: name, category: category };
   });

--- a/src/pages/HomePage.test.jsx
+++ b/src/pages/HomePage.test.jsx
@@ -19,12 +19,21 @@ describe('HomePage', () => {
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      getCondition: 
-      { id: 10, name: '청와옥', condition: '과음한 다음 날', color: 'blue' },
-      getRegion: 
-      { id: 10, name: '청와옥', region: '서울 송파구', color: 'blue' },
-      getCategory: 
-      { id: 10, name: '청와옥', category: '순대국밥', color: 'blue' },
+      sortedConditions: [
+        { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue' }
+      ],
+      sortedRegions: [
+        { id: 1, name: '청와옥', condition: '서울 송파구', color: 'blue' }
+      ],
+      sortedCategories: [
+        { id: 1, name: '청와옥', condition: '순대국밥', color: 'blue' }
+      ],
+      selectedCondition: 
+      { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue'},
+      selectedRegion: 
+      { id: 1, name: '청와옥', condition: '서울 송파구', color: 'blue'},
+      selectedCategory: 
+      { id: 1, name: '청와옥', condition: '순대국밥', color: 'blue'},
     }));
   });
 

--- a/src/pages/HomePage.test.jsx
+++ b/src/pages/HomePage.test.jsx
@@ -23,17 +23,17 @@ describe('HomePage', () => {
         { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue' }
       ],
       sortedRegions: [
-        { id: 1, name: '청와옥', condition: '서울 송파구', color: 'blue' }
+        { id: 1, name: '청와옥', region: '서울 송파구', color: 'blue' }
       ],
       sortedCategories: [
-        { id: 1, name: '청와옥', condition: '순대국밥', color: 'blue' }
+        { id: 1, name: '청와옥', category: '순대국밥', color: 'blue' }
       ],
       selectedCondition: 
       { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue'},
       selectedRegion: 
-      { id: 1, name: '청와옥', condition: '서울 송파구', color: 'blue'},
+      { id: 1, name: '청와옥', region: '서울 송파구', color: 'blue'},
       selectedCategory: 
-      { id: 1, name: '청와옥', condition: '순대국밥', color: 'blue'},
+      { id: 1, name: '청와옥', category: '순대국밥', color: 'blue'},
     }));
   });
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -27,7 +27,7 @@ const reducers = {
       newId: newId + 1,
       restaurant: {
         id: newId,
-        name: value, // 인풋값이 name으로 설정됨
+        name: value,
       },
     }
   },
@@ -89,10 +89,8 @@ const reducers = {
     }
   },
 
-  // conditionObject 받아서 conditions 어레이중에 가게이름 일치하는 객체만 남김
   sortByCondition(state, { payload: { selectedName } }) {
     const {conditions} = state;
-    console.log(conditions);
 
     return {
       ...state,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,10 +1,3 @@
-// ToDo delete
-import {
-  conditions,
-  regions,
-  categories,
-} from './data/hashTags';
-
 const initialState = {
   color: '',
   newId: 100,
@@ -17,13 +10,13 @@ const initialState = {
   selectedRegion: null, 
   selectedCategory: null, 
 
-  getCondition: null, 
-  getRegion: null,
-  getCategory: null,
+  sortedConditions: [],
+  sortedRegions: [],
+  sortedCategories: [],
 
-  newCondtions: [], // ToDo conditions로 이름 바꾸기
-  newRegions: [],
-  newCategories: [],
+  conditions: [],
+  regions: [],
+  categories: [],
 };
 
 const reducers = {
@@ -42,25 +35,27 @@ const reducers = {
   setConditions(state, { payload: { conditionsArr } }) {
     return {
       ...state,
-      newConditions: conditionsArr,
+      conditions: conditionsArr,
     }
   },
 
   setRegions(state, { payload: { regionsArr } }) {
     return {
       ...state,
-      newRegions: regionsArr,
+      regions: regionsArr,
     }
   },
 
   setCategories(state, { payload: { categoriesArr } }) {
     return {
       ...state,
-      newCategories: categoriesArr,
+      categories: categoriesArr,
     }
   },
 
   selectConditionTag(state, { payload: { selectedId } }) {
+    const {conditions} = state;
+
     return {
       ...state,
       selectedCondition: {
@@ -71,6 +66,8 @@ const reducers = {
   },
 
   selectRegionTag(state, { payload: { selectedId } }) {
+    const {regions} = state;
+
     return {
       ...state,
       selectedRegion: {
@@ -81,6 +78,8 @@ const reducers = {
   },
 
   selectCategoryTag(state, { payload: { selectedId } }) {
+    const {categories} = state;
+
     return {
       ...state,
       selectedCategory: {
@@ -90,33 +89,38 @@ const reducers = {
     }
   },
 
-  getConditionTag(state, { payload: { conditionObj } }) {
+  // conditionObject 받아서 conditions 어레이중에 가게이름 일치하는 객체만 남김
+  sortByCondition(state, { payload: { selectedName } }) {
+    const {conditions} = state;
+    console.log(conditions);
+
     return {
       ...state,
-      getCondition: {
-        ...conditionObj,
-        color: "blue",
-      },
+      sortedConditions: [
+        conditions.filter(condition => condition.condition === selectedName)
+      ],
     }
   },
 
-  getRegionTag(state, { payload: { regionObj } }) {
+  sortByRegion(state, { payload: { selectedName } }) {
+    const {regions} = state;
+
     return {
       ...state,
-      getRegion: {
-        ...regionObj,
-        color: "blue",
-      },
+      sortedRegions: [
+        regions.filter(region => region.region === selectedName)
+      ],
     }
   },
 
-  getCategoryTag(state, { payload: { categoryObj } }) {
+  sortByCategory(state, { payload: { selectedName } }) {
+    const {categories} = state;
+
     return {
       ...state,
-      getCategory: {
-        ...categoryObj,
-        color: "blue",
-      },
+      sortedCategories: [
+        categories.filter(category => category.category === selectedName)
+      ],
     }
   },
 }

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -18,13 +18,6 @@ import {
 jest.mock('react-redux');
 
 describe('reducer', () => {
-  // find, filter 메서드 모킹하는 방법?
-  const find = jest.fn();
-  const filter = jest.fn();
-
-  find.mockImplementation(() => find());
-  find.mockImplementation(() => filter());
-
   describe('setRestaurantName action', () => {
     it('changes state of restaurantName from "" to "입력값" and update id', () => {
       const initialState = {
@@ -96,52 +89,74 @@ describe('reducer', () => {
   });
 
   describe('selectConditionTag action', () => {
-    it('set selectedCondition', () => {
+    const selectedId = 1;
+
+    it('sorts "conditions" array by selected id and sets "selectedCondition" obj', () => {
       const initialState = {
+        conditions: [
+          {id: 1, name: '청와옥', condition: '과음한 다음 날'},
+          {id: 2, name: '멘카야', condition: '혼밥'}
+        ],
         selectedCondition: null,
       }
 
-      const state = reducer(initialState, selectConditionTag(1));
+      const state = reducer(initialState, selectConditionTag(selectedId));
 
       expect(state.selectedCondition).toEqual({
-        id: 1, name: '청와옥', condition: '혼밥', color: 'blue',
+        id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue',
       });
     });
   });
 
   describe('selectRegionTag action', () => {
-    it('set selectedRegion', () => {
+    const selectedId = 1;
+
+    it('sorts "regions" array by selected id and sets "selectedRegion" obj', () => {
       const initialState = {
+        regions: [
+          {id: 1, name: '청와옥', region: '서울 송파구'},
+          {id: 2, name: '멘카야', region: '서울 강남구'}
+        ],
         selectedRegion: null,
       }
 
-      const state = reducer(initialState, selectRegionTag(1));
+      const state = reducer(initialState, selectRegionTag(selectedId));
 
       expect(state.selectedRegion).toEqual({
-        id: 1, name: '청와옥', condition: '서울 송파구', color: 'blue',
+        id: 1, name: '청와옥', region: '서울 송파구', color: 'blue',
       });
     });
   });
 
   describe('selectCategoryTag action', () => {
-    it('set selectedCategory', () => {
+    const selectedId = 1;
+
+    it('sorts "categories" array by selected id and sets "selectedCategory" obj', () => {
       const initialState = {
+        categories: [
+          {id: 1, name: '청와옥', category: '순대국밥'},
+          {id: 2, name: '멘카야', category: '라멘'}
+        ],
         selectedCategory: null,
       }
 
-      const state = reducer(initialState, selectCategoryTag(1));
+      const state = reducer(initialState, selectCategoryTag(selectedId));
 
       expect(state.selectedCategory).toEqual({
-        id: 1, name: '청와옥', condition: '순대국밥', color: 'blue',
+        id: 1, name: '청와옥', category: '순대국밥', color: 'blue',
       });
     });
   });
 
   describe('sortByCondition action', () => {
-    it('sorts conditions array', () => {
-      const selectedName = '청와옥';
+    it('sorts "conditions" array by condition keyword and puts data in "sortedConditions" array', () => {
+      const selectedName = '과음한 다음 날';
 
       const initialState = {
+        conditions: [
+          {id: 1, name: '청와옥', condition: '과음한 다음 날'},
+          {id: 2, name: '멘카야', condition: '혼밥'}
+        ],
         sortedConditions: [],
       }
 
@@ -152,10 +167,14 @@ describe('reducer', () => {
   });
 
   describe('sortByRegion action', () => {
-    it('sorts regions array', () => {
-      const selectedName = '청와옥';
+    it('sorts "regions" array by region keyword and puts data in "sortedRegions" array', () => {
+      const selectedName = '서울 송파구';
 
       const initialState = {
+        regions: [
+          {id: 1, name: '청와옥', region: '서울 송파구'},
+          {id: 2, name: '멘카야', region: '서울 강남구'}
+        ],
         sortedRegions: [],
       }
 
@@ -166,10 +185,14 @@ describe('reducer', () => {
   });
 
   describe('sortByCategory action', () => {
-    it('sorts categories array', () => {
-      const selectedName = '청와옥';
+    it('sorts "categories" array by categorie keyword and puts data in "sortedCategories" array', () => {
+      const selectedName = '순대국밥';
 
       const initialState = {
+        categories: [
+          {id: 1, name: '청와옥', categorie: '순대국밥'},
+          {id: 2, name: '멘카야', categorie: '라멘'}
+        ],
         sortedCategories: [],
       }
 

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -5,15 +5,26 @@ import {
   setConditions,
   setRegions,
   setCategories,
+
   selectConditionTag,
   selectRegionTag,
   selectCategoryTag,
-  getConditionTag,
-  getRegionTag,
-  getCategoryTag,
+  
+  sortByCondition,
+  sortByRegion,
+  sortByCategory,
 } from './actions';
 
+jest.mock('react-redux');
+
 describe('reducer', () => {
+  // find, filter 메서드 모킹하는 방법?
+  const find = jest.fn();
+  const filter = jest.fn();
+
+  find.mockImplementation(() => find());
+  find.mockImplementation(() => filter());
+
   describe('setRestaurantName action', () => {
     it('changes state of restaurantName from "" to "입력값" and update id', () => {
       const initialState = {
@@ -37,9 +48,9 @@ describe('reducer', () => {
   });
 
   describe('setConditions action', () => {
-    it('changes state of newConditions with sorted JSON data', () => {
+    it('changes state of conditions with sorted JSON data', () => {
       const initialState = {
-        newConditions: [],
+        conditions: [],
       };
 
       const conditionsArr = [
@@ -48,14 +59,14 @@ describe('reducer', () => {
 
       const state = reducer(initialState, setConditions(conditionsArr));
 
-      expect(state.newConditions).toHaveLength(1);
+      expect(state.conditions).toHaveLength(1);
     });
   });
 
   describe('setRegions action', () => {
-    it('changes state of newRegions with sorted JSON data', () => {
+    it('changes state of regions with sorted JSON data', () => {
       const initialState = {
-        newRegions: [],
+        regions: [],
       };
 
       const regionsArr = [
@@ -64,14 +75,14 @@ describe('reducer', () => {
 
       const state = reducer(initialState, setRegions(regionsArr));
 
-      expect(state.newRegions).toHaveLength(1);
+      expect(state.regions).toHaveLength(1);
     });
   });
 
   describe('setCategories action', () => {
-    it('changes state of newCategories with sorted JSON data', () => {
+    it('changes state of categories with sorted JSON data', () => {
       const initialState = {
-        newCategories: [],
+        categories: [],
       };
 
       const categoriesArr = [
@@ -80,7 +91,7 @@ describe('reducer', () => {
 
       const state = reducer(initialState, setCategories(categoriesArr));
 
-      expect(state.newCategories).toHaveLength(1);
+      expect(state.categories).toHaveLength(1);
     });
   });
 
@@ -93,7 +104,7 @@ describe('reducer', () => {
       const state = reducer(initialState, selectConditionTag(1));
 
       expect(state.selectedCondition).toEqual({
-        id: 1, name: '#혼밥', color: 'blue',
+        id: 1, name: '청와옥', condition: '혼밥', color: 'blue',
       });
     });
   });
@@ -107,7 +118,7 @@ describe('reducer', () => {
       const state = reducer(initialState, selectRegionTag(1));
 
       expect(state.selectedRegion).toEqual({
-        id: 1, name: '#서울 송파구', color: 'blue',
+        id: 1, name: '청와옥', condition: '서울 송파구', color: 'blue',
       });
     });
   });
@@ -121,59 +132,50 @@ describe('reducer', () => {
       const state = reducer(initialState, selectCategoryTag(1));
 
       expect(state.selectedCategory).toEqual({
-        id: 1, name: '#면', color: 'blue',
+        id: 1, name: '청와옥', condition: '순대국밥', color: 'blue',
       });
     });
   });
 
-  describe('getConditionTag action', () => {
-    it('set getCondtion', () => {
-      const conditionObj = 
-      { id: 10, name: '청와옥', condition: '과음한 다음 날' };
+  describe('sortByCondition action', () => {
+    it('sorts conditions array', () => {
+      const selectedName = '청와옥';
 
       const initialState = {
-        getCondition: null,
+        sortedConditions: [],
       }
 
-      const state = reducer(initialState, getConditionTag(conditionObj));
+      const state = reducer(initialState, sortByCondition(selectedName));
 
-      expect(state.getCondition).toEqual({
-        id: 10, name: '청와옥', condition: '과음한 다음 날', color: 'blue',
-      });
+      expect(state.sortedConditions).toHaveLength(1);
     });
   });
 
-  describe('getRegionTag action', () => {
-    it('set getCondtion', () => {
-    const regionObj = 
-    { id: 10, name: '청와옥', region: '서울 송파구' };
+  describe('sortByRegion action', () => {
+    it('sorts regions array', () => {
+      const selectedName = '청와옥';
 
       const initialState = {
-        getRegion: null,
+        sortedRegions: [],
       }
 
-      const state = reducer(initialState, getRegionTag(regionObj));
+      const state = reducer(initialState, sortByRegion(selectedName));
 
-      expect(state.getRegion).toEqual({
-        id: 10, name: '청와옥', region: '서울 송파구', color: 'blue'
-      });
+      expect(state.sortedRegions).toHaveLength(1);
     });
   });
 
-  describe('getCategoryTag action', () => {
-    it('set getCategory', () => {
-    const categoryObj = 
-    { id: 10, name: '청와옥', category: '순대국밥' };
+  describe('sortByCategory action', () => {
+    it('sorts categories array', () => {
+      const selectedName = '청와옥';
 
       const initialState = {
-        getCategory: null,
+        sortedCategories: [],
       }
 
-      const state = reducer(initialState, getCategoryTag(categoryObj));
+      const state = reducer(initialState, sortByCategory(selectedName));
 
-      expect(state.getCategory).toEqual({
-        id: 10, name: '청와옥', category: '순대국밥', color: 'blue'
-      });
+      expect(state.sortedCategories).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## 해시태그 다중선택시 해당하는 가게목록 보여주기

#### Progressing 
👉🏻 사용자는 해시태그를 선택해서 그에 해당하는 가게목록을 볼 수 있습니다.

> **[Structure]** 
> App > HomePage > 
> HomeConditionTagsContainer (어떤 상황인가요?)
> HomeRegionTagsContainer (어디로 가고 싶나요?)
> HomeCategoryTagsContainer (무엇을 드시고 싶으세요?)
> - [x] 해시태그 클릭했을때 상황, 지역, 분류 키워드 기준으로 JSON데이터 솔팅됨

### ToDoNext
지금은 JSON데이터 뭉탱이 배열에서 
상황, 지역, 분류 별로 각각 conditionsArr, regionsArr, caregoriesArr 등으로 스토어에 나누어서 저장되고있다.
태그를 하나씩 누를때마다 가게이름이 걸러져서 나오도록 로직을 짜보자...