### PR TITLE
[220212] Change variable identifier to filter restaurants array in order

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -19,9 +19,6 @@ describe('App', () => {
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      sortedRestaurants: [
-        { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue' }
-      ],
       selectedCondition: 
       { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue'},
       selectedRegion: 

--- a/src/actions.js
+++ b/src/actions.js
@@ -33,23 +33,23 @@ export function selectCategoryTag(selectedId) {
   }
 }
 
-export function sortByCondition(selectedName) {
+export function sortRestaurantsByCondition(selectedTag) {
   return {
-    type: 'sortByCondition',
-    payload: { selectedName },
+    type: 'sortRestaurantsByCondition',
+    payload: { selectedTag },
   }
 }
 
-export function sortByRegion(selectedName) {
+export function sortRestaurantsByRegion(selectedTag) {
   return {
-    type: 'sortByRegion',
-    payload: { selectedName },
+    type: 'sortRestaurantsByRegion',
+    payload: { selectedTag },
   }
 }
 
-export function sortByCategory(selectedName) {
+export function sortRestaurantsByCategory(selectedTag) {
   return {
-    type: 'sortByCategory',
-    payload: { selectedName },
+    type: 'sortRestaurantsByCategory',
+    payload: { selectedTag },
   }
 }

--- a/src/containers/HomeCategoryTagsContainer.jsx
+++ b/src/containers/HomeCategoryTagsContainer.jsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import {
   setRestaurants,
-  sortByCategory,
+  sortRestaurantsByCategory,
   selectCategoryTag,
 } from '../actions';
 
@@ -33,8 +33,8 @@ export default function HomeCategoryTagsContainer({ restaurantsData }) {
     dispatch(setRestaurants(restaurantsData));
   }, []);
 
-  function handleClickTag(selectedName, selectedId) {
-    dispatch(sortByCategory(selectedName));
+  function handleClickTag(selectedTag, selectedId) {
+    dispatch(sortRestaurantsByCategory(selectedTag));
     dispatch(selectCategoryTag(selectedId));
   }
 
@@ -44,10 +44,10 @@ export default function HomeCategoryTagsContainer({ restaurantsData }) {
   ));
   const {color} = selectedCategory;
 
-  const sortedRestaurants = useSelector((state) => ({
-    sortedRestaurants: state.sortedRestaurants,
+  const sortedRestaurantsByCategory = useSelector((state) => ({
+    sortedRestaurantsByCategory: state.sortedRestaurantsByCategory,
   }));
-  console.log(sortedRestaurants);
+  console.log(sortedRestaurantsByCategory);
 
   return (
     <TagsBox>

--- a/src/containers/HomeCategoryTagsContainer.test.jsx
+++ b/src/containers/HomeCategoryTagsContainer.test.jsx
@@ -53,16 +53,16 @@ describe('HomeCategoryTagsContainer', () => {
   });
 
   context('when click "#순대국밥" tag', () => {
-    const selectedName = '순대국밥';
+    const selectedTag = '순대국밥';
 
-    it('calls dispatch with action : sortByCategory', () => {
+    it('calls dispatch with action : sortRestaurantsByCategory', () => {
       const { getByText } = renderHomeCategoryTagsContainer();
 
       fireEvent.click(getByText('#순대국밥'));
 
       expect(dispatch).toBeCalledWith({
-        type: 'sortByCategory',
-        payload: { selectedName },
+        type: 'sortRestaurantsByCategory',
+        payload: { selectedTag },
       })
     });
   });

--- a/src/containers/HomeConditionTagsContainer.jsx
+++ b/src/containers/HomeConditionTagsContainer.jsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import {
   setRestaurants,
-  sortByCondition,
+  sortRestaurantsByCondition,
   selectConditionTag,
 } from '../actions';
 
@@ -33,8 +33,8 @@ export default function HomeConditionTagsContainer({ restaurantsData }) {
     dispatch(setRestaurants(restaurantsData));
   }, []);
 
-  function handleClickTag(selectedName, selectedId) {
-    dispatch(sortByCondition(selectedName));
+  function handleClickTag(selectedTag, selectedId) {
+    dispatch(sortRestaurantsByCondition(selectedTag));
     dispatch(selectConditionTag(selectedId));
   }
 
@@ -44,10 +44,10 @@ export default function HomeConditionTagsContainer({ restaurantsData }) {
   ));
   const {color} = selectedCondition;
 
-  const sortedRestaurants = useSelector((state) => ({
-    sortedRestaurants: state.sortedRestaurants,
+  const sortedRestaurantsByCondition = useSelector((state) => ({
+    sortedRestaurantsByCondition: state.sortedRestaurantsByCondition,
   }));
-  console.log(sortedRestaurants);
+  console.log(sortedRestaurantsByCondition);
 
   return (
     <TagsBox>

--- a/src/containers/HomeConditionTagsContainer.test.jsx
+++ b/src/containers/HomeConditionTagsContainer.test.jsx
@@ -53,16 +53,16 @@ describe('HomeConditionTagsContainer', () => {
   });
 
   context('when click "#과음한 다음 날" tag', () => {
-    const selectedName = '과음한 다음 날';
+    const selectedTag = '과음한 다음 날';
 
-    it('calls dispatch with action : sortByCondition', () => {
+    it('calls dispatch with action : sortRestaurantsByCondition', () => {
       const { getByText } = renderHomeConditionTagsContainer();
 
       fireEvent.click(getByText('#과음한 다음 날'));
 
       expect(dispatch).toBeCalledWith({
-        type: 'sortByCondition',
-        payload: { selectedName },
+        type: 'sortRestaurantsByCondition',
+        payload: { selectedTag },
       })
     });
   });

--- a/src/containers/HomeRegionTagsContainer.jsx
+++ b/src/containers/HomeRegionTagsContainer.jsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import {
   setRestaurants,
-  sortByRegion,
+  sortRestaurantsByRegion,
   selectRegionTag,
 } from '../actions';
 
@@ -33,8 +33,8 @@ export default function HomeRegionTagsContainer({ restaurantsData }) {
     dispatch(setRestaurants(restaurantsData));
   }, []);
 
-  function handleClickTag(selectedName, selectedId) {
-    dispatch(sortByRegion(selectedName));
+  function handleClickTag(selectedTag, selectedId) {
+    dispatch(sortRestaurantsByRegion(selectedTag));
     dispatch(selectRegionTag(selectedId));
   }
 
@@ -44,10 +44,10 @@ export default function HomeRegionTagsContainer({ restaurantsData }) {
   ));
   const {color} = selectedRegion;
 
-  const sortedRestaurants = useSelector((state) => ({
-    sortedRestaurants: state.sortedRestaurants,
+  const sortedRestaurantsByRegion = useSelector((state) => ({
+    sortedRestaurantsByRegion: state.sortedRestaurantsByRegion,
   }));
-  console.log(sortedRestaurants);
+  console.log(sortedRestaurantsByRegion);
 
   return (
     <TagsBox>

--- a/src/containers/HomeRegionTagsContainer.test.jsx
+++ b/src/containers/HomeRegionTagsContainer.test.jsx
@@ -53,16 +53,16 @@ describe('HomeRegionTagsContainer', () => {
   });
 
   context('when click "#서울 송파구" tag', () => {
-    it('calls dispatch with action : sortByRegion', () => {
-      const selectedName = '서울 송파구';
+    it('calls dispatch with action : sortRestaurantsByRegion', () => {
+      const selectedTag = '서울 송파구';
 
       const { getByText } = renderHomeRegionTagsContainer();
 
       fireEvent.click(getByText('#서울 송파구'));
 
       expect(dispatch).toBeCalledWith({
-        type: 'sortByRegion',
-        payload: { selectedName },
+        type: 'sortRestaurantsByRegion',
+        payload: { selectedTag },
       })
     });
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -10,6 +10,7 @@ import {
 
 const HomePageLayout = styled.div({
   display: 'flex',
+  flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
   width: '100%',
@@ -18,8 +19,8 @@ const HomePageLayout = styled.div({
 
 const TagsLayout = styled.div({
   textAlign: 'left',
-  marginRight: '48px',
-  "& h2": {
+  marginBottom: '48px',
+  "& h4": {
     marginBottom: '24px',
   },
 });
@@ -33,6 +34,7 @@ export default function HomePage({ restaurants }) {
     <HomePageLayout>
       <TagsLayout>
         <h2>어디 갈지 모르겠다구요? 👀</h2>
+        <h4>순서대로 원하시는 태그를 선택해주세요!</h4>
         <HomeConditionTagsContainer
           restaurantsData={restaurants}
         />

--- a/src/pages/HomePage.test.jsx
+++ b/src/pages/HomePage.test.jsx
@@ -19,9 +19,6 @@ describe('HomePage', () => {
     useDispatch.mockImplementation(() => dispatch);
 
     useSelector.mockImplementation((selector) => selector({
-      sortedRestaurants: [
-        { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue' }
-      ],
       selectedCondition: 
       { id: 1, name: '청와옥', condition: '과음한 다음 날', color: 'blue'},
       selectedRegion: 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -11,7 +11,9 @@ const initialState = {
   selectedRegion: null, 
   selectedCategory: null, 
 
-  sortedRestaurants: [],
+  sortedRestaurantsByCondition: [],
+  sortedRestaurantsByRegion: [],
+  sortedRestaurantsByCategory: [],
 
   restaurants: [],
 };
@@ -72,38 +74,38 @@ const reducers = {
     }
   },
 
-  sortByCondition(state, { payload: { selectedName } }) {
+  sortRestaurantsByCondition(state, { payload: { selectedTag } }) {
     const {restaurants} = state;
+    console.log(restaurants);
 
     return {
       ...state,
-      sortedRestaurants: [
-        restaurants.filter(condition => condition.condition === selectedName)
-      ],
+      sortedRestaurantsByCondition: 
+        restaurants.filter(condition => condition.condition === selectedTag),
     }
   },
 
-  sortByRegion(state, { payload: { selectedName } }) {
-    const {restaurants} = state;
+  sortRestaurantsByRegion(state, { payload: { selectedTag } }) {
+    const {sortedRestaurantsByCondition} = state;
+    console.log(sortedRestaurantsByCondition);
 
     return {
       ...state,
-      sortedRestaurants: [
-        restaurants.filter(region => region.region === selectedName)
-      ],
+      sortedRestaurantsByRegion: 
+      sortedRestaurantsByCondition.filter(region => region.region === selectedTag),
     }
   },
 
-  sortByCategory(state, { payload: { selectedName } }) {
-    const {restaurants} = state;
-
+  sortRestaurantsByCategory(state, { payload: { selectedTag } }) {
+    const {sortedRestaurantsByRegion} = state;
+    console.log(sortedRestaurantsByRegion);
+  
     return {
       ...state,
-      sortedRestaurants: [
-        restaurants.filter(category => category.category === selectedName)
-      ],
+      sortedRestaurantsByCategory: 
+        sortedRestaurantsByRegion.filter(category => category.category === selectedTag),
     }
-  },
+  }
 }
 
 function defaultReducer(state) {

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -8,9 +8,9 @@ import {
   selectRegionTag,
   selectCategoryTag,
   
-  sortByCondition,
-  sortByRegion,
-  sortByCategory,
+  sortRestaurantsByCondition,
+  sortRestaurantsByRegion,
+  sortRestaurantsByCategory,
 } from './actions';
 
 jest.mock('react-redux');
@@ -114,58 +114,57 @@ describe('reducer', () => {
     });
   });
 
-  describe('sortByCondition action', () => {
-    it('sorts "restaurants" array by condition keyword and puts data in "sortedRestaurants" array', () => {
-      const selectedName = '과음한 다음 날';
+  describe('sortRestaurantsByCondition action', () => {
+    it('sorts "restaurants" array by hash tag keyword and puts data in "sortedRestaurantsByCondition" array', () => {
+      const selectedTag = '과음한 다음 날';
 
       const initialState = {
         restaurants: [
           {id: 1, name: '청와옥', condition: '과음한 다음 날'},
           {id: 2, name: '멘카야', condition: '혼밥'}
         ],
-        sortedRestaurants: [],
+        sortedRestaurantsByCondition: [],
       }
 
-      const state = reducer(initialState, sortByCondition(selectedName));
+      const state = reducer(initialState, sortRestaurantsByCondition(selectedTag));
 
-      expect(state.sortedRestaurants).toHaveLength(1);
+      expect(state.sortedRestaurantsByCondition).toHaveLength(1);
     });
   });
 
-  // ToDo delete
-  describe('sortByRegion action', () => {
-    it('sorts "restaurants" array by region keyword and puts data in "sortedRestaurants" array', () => {
-      const selectedName = '서울 송파구';
+  describe('sortRestaurantsByRegion action', () => {
+    it('sorts "sortedRestaurantsByCondition" array by hash tag keyword and puts data in "sortedRestaurantsByRegion" array', () => {
+      const selectedTag = '서울 송파구';
 
       const initialState = {
-        restaurants: [
+        sortedRestaurantsByCondition: [
           {id: 1, name: '청와옥', region: '서울 송파구'},
           {id: 2, name: '멘카야', region: '서울 강남구'}
         ],
-        sortedRestaurants: [],
+        sortedRestaurantsByRegion: [],
       }
 
-      const state = reducer(initialState, sortByRegion(selectedName));
+      const state = reducer(initialState, sortRestaurantsByRegion(selectedTag));
 
-      expect(state.sortedRestaurants).toHaveLength(1);
+      expect(state.sortedRestaurantsByRegion).toHaveLength(1);
     });
   });
 
-  describe('sortByCategory action', () => {
-    it('sorts "restaurants" array by categorie keyword and puts data in "sortedRestaurants" array', () => {
-      const selectedName = '순대국밥';
+  describe('sortRestaurantsByCategory action', () => {
+    it('sorts "sortedRestaurantsByRegion" array by hash tag keyword and puts data in "sortedRestaurantsByCategory" array', () => {
+      const selectedTag = '순대국밥';
 
       const initialState = {
-        restaurants: [
-          {id: 1, name: '청와옥', categorie: '순대국밥'},
-          {id: 2, name: '멘카야', categorie: '라멘'}
+        sortedRestaurantsByRegion: [
+          {id: 1, name: '청와옥', category: '순대국밥'},
+          {id: 2, name: '멘카야', category: '일본식 라면'}
         ],
-        sortedRestaurants: [],
+        sortedRestaurantsByCategory: [],
       }
 
-      const state = reducer(initialState, sortByCategory(selectedName));
+      const state = reducer(initialState, sortRestaurantsByCategory(selectedTag));
 
-      expect(state.sortedRestaurants).toHaveLength(1);
+      expect(state.sortedRestaurantsByCategory).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## 해시태그 다중선택시 해당하는 가게목록 보여주기

#### Progressing 
👉🏻 사용자는 해시태그를 선택해서 그에 해당하는 가게목록을 볼 수 있습니다.

> **[Structure]** 
> App > HomePage > 
> HomeConditionTagsContainer (어떤 상황인가요?)
> HomeRegionTagsContainer (어디로 가고 싶나요?)
> HomeCategoryTagsContainer (무엇을 드시고 싶으세요?)
> - [x] 변수명수정222 -> 뭉탱이 restaurants 배열에서 시작해서 상황, 지역, 분류 태그 누를때마다 순차적으로 솔팅되게 함

### ToDoNext
가게이름 화면에 보이게 하기