### PR TITLE
[220214] Get Kakao map api and render restaurants list & map

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,13 +26,19 @@
 
     <div id="app"></div>
 
+    <div id="map" style="width:100%;height:100%;position:relative;overflow:hidden;"></div>
+
     <footer class="mt-auto text-white-50">
       <p>This page has been prepared by <a href="https://github.com/Superduper-India"
           class="text-white">@Superduper-India</a></p>
     </footer>
   </div>
-
   <script src="main.js"></script>
+  <!-- Kakao api -->
+  <script 
+    type="text/javascript" 
+    src="//dapi.kakao.com/v2/maps/sdk.js?appkey=8cbe20f536259f558e9b3a52f704bca0&libraries=services,clusterer,drawing">
+  </script>
 </body>
 
 </html>

--- a/services/api.js
+++ b/services/api.js
@@ -1,0 +1,6 @@
+export function fetchSearchResult(keyword) {
+  const url = 'https://map.kakao.com/link'
+  + `/search/${keyword}`; // 검색어(keyword)를 이용하여 검색결과를 표시한 상태의 URL를 만듦
+
+  console.log(url);
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import {
 import HomePage from './pages/HomePage';
 import BoardPage from './pages/BoardPage';
 import PostFormPage from './pages/PostFormPage';
+import MapPage from './pages/MapPage';
 
 import restaurants from '../assets/json/restaurants.json';
 
@@ -17,6 +18,7 @@ export default function App() {
       />} />
       <Route path="/board" element={<BoardPage />} />
       <Route path="/post" element={<PostFormPage />} />
+      <Route path="/map/:name" element={<MapPage />} />
     </Routes>
   )
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,3 +1,7 @@
+import {
+  fetchSearchResult,
+} from '../services/api';
+
 export function setRestaurantName({ value }) {
   return {
     type: 'setRestaurantName',
@@ -12,6 +16,8 @@ export function setRestaurants(restaurantsData) {
   }
 }
 
+/* export function setResultRestaurant()
+ */
 export function selectConditionTag(selectedId) {
   return {
     type: 'selectConditionTag',
@@ -52,4 +58,12 @@ export function sortRestaurantsByCategory(selectedTag) {
     type: 'sortRestaurantsByCategory',
     payload: { selectedTag },
   }
+}
+
+export function loadSearchResult(keyword) {
+  return async () => {
+    await fetchSearchResult(keyword);
+
+    // dispatch(setResultRestaurant(resultRestaurant));
+  };
 }

--- a/src/containers/HomeRestaurantsContainer.jsx
+++ b/src/containers/HomeRestaurantsContainer.jsx
@@ -4,6 +4,8 @@ import uniqBy from 'lodash.uniqby';
 
 import { useSelector } from 'react-redux';
 
+import { Link } from 'react-router-dom';
+
 const RestaurantsBox = styled.div({
   width: '40%',
   display: 'flex',
@@ -33,9 +35,14 @@ export default function HomeRestaurantsContainer() {
           <h4>결과가 없어요! 😥</h4>
           :
           uniqRestaurants.map((obj) => (
-            <h4 key={obj.id}>
+            <Link
+              key={obj.id}
+              to={
+                `/map/${obj.name}`
+              }
+            >
               {obj.name}
-            </h4>
+            </Link>
           ))
         }
       </RestaurantsBox>

--- a/src/containers/MapContainer.jsx
+++ b/src/containers/MapContainer.jsx
@@ -1,0 +1,15 @@
+export default function MapContainer({ keyword }) {
+  function handleClick(keyword) {
+    window.location.assign(`https://map.kakao.com/link/search/${keyword}`)
+  }
+
+  return (
+    <>
+      <button
+        type='button'
+        onClick={() => handleClick(keyword)}>
+      지도에서 보기
+      </button>
+    </>
+  )
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,8 +4,6 @@ import {
 
 import { Provider } from 'react-redux';
 
-import React from 'react';
-
 import ReactDOM from 'react-dom';
 
 import App from './App';

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -15,11 +15,11 @@ const HomePageLayout = styled.div({
   justifyContent: 'center',
   width: '100%',
   height: '100%',
+  margin: '48px 0',
 });
 
 const Tags = styled.div({
   textAlign: 'left',
-  marginBottom: '48px',
   '& h4': {
     marginBottom: '48px',
   },
@@ -31,6 +31,7 @@ const TagSearch = styled.div({
 });
 
 const Post = styled.div({
+  marginTop: '12px',
   textAlign: 'center',
 });
 

--- a/src/pages/MapContainer.jsx
+++ b/src/pages/MapContainer.jsx
@@ -1,9 +1,0 @@
-export default function MapContainer({ keyword }) {
-  console.log(keyword);
-
-  return (
-    <>
-      <h1>상세보기</h1>
-    </>
-  )
-}

--- a/src/pages/MapContainer.jsx
+++ b/src/pages/MapContainer.jsx
@@ -1,0 +1,9 @@
+export default function MapContainer({ keyword }) {
+  console.log(keyword);
+
+  return (
+    <>
+      <h1>상세보기</h1>
+    </>
+  )
+}

--- a/src/pages/MapPage.jsx
+++ b/src/pages/MapPage.jsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 
 import { useEffect } from 'react';
 
-import MapContainer from './MapContainer';
+import MapContainer from '../containers/MapContainer';
 
 const PlacesList = styled.ul({
   textAlign: 'start',
@@ -18,10 +18,10 @@ export default function MapPage({ params }) {
 
   const { kakao } = window;
 
-  // 마커를 담을 배열입니다
-  var markers = [];
-
   useEffect(() => {
+    // 마커를 담을 배열입니다
+    var markers = [];
+
     const mapContainer = document.getElementById('map'); // 지도를 표시할 div
     const mapOption = {
       center: new kakao.maps.LatLng(37.566826, 126.9786567), // 지도의 중심좌표
@@ -141,7 +141,7 @@ export default function MapPage({ params }) {
       var el = document.createElement('li'),
         itemStr = '<span class="markerbg marker_' + (index + 1) + '"></span>' +
               '<div class="info">' +
-              '   <h5>' + places.place_name + '</h5>';
+              '<h5>' + places.place_name + '</h5>';
 
       if (places.road_address_name) {
         itemStr += '    <span>' + places.road_address_name + '</span>' +

--- a/src/pages/MapPage.jsx
+++ b/src/pages/MapPage.jsx
@@ -1,0 +1,268 @@
+import styled from '@emotion/styled';
+
+import { useParams } from 'react-router-dom';
+
+import { useEffect } from 'react';
+
+import MapContainer from './MapContainer';
+
+const PlacesList = styled.ul({
+  textAlign: 'start',
+  '& li': {
+    marginBottom: '24px',
+  },
+});
+
+export default function MapPage({ params }) {
+  const { name } = params || useParams();
+
+  const { kakao } = window;
+
+  // 마커를 담을 배열입니다
+  var markers = [];
+
+  useEffect(() => {
+    const mapContainer = document.getElementById('map'); // 지도를 표시할 div
+    const mapOption = {
+      center: new kakao.maps.LatLng(37.566826, 126.9786567), // 지도의 중심좌표
+      level: 3, // 지도의 확대 레벨
+    };
+
+    // 지도를 생성합니다
+    const map = new kakao.maps.Map(mapContainer, mapOption);
+
+    // 장소 검색 객체를 생성합니다
+    var ps = new kakao.maps.services.Places();
+
+    // 검색 결과 목록이나 마커를 클릭했을 때 장소명을 표출할 인포윈도우를 생성합니다
+    var infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
+
+    // 키워드로 장소를 검색합니다
+    searchPlaces();
+
+    // 키워드 검색을 요청하는 함수입니다
+    function searchPlaces() {
+
+      var keyword = name;
+
+      if (!keyword.replace(/^\s+|\s+$/g, '')) {
+        alert('키워드를 입력해주세요!');
+        return false;
+      }
+
+      // 장소검색 객체를 통해 키워드로 장소검색을 요청합니다
+      ps.keywordSearch(keyword, placesSearchCB);
+    }
+
+    // 장소검색이 완료됐을 때 호출되는 콜백함수 입니다
+    function placesSearchCB(data, status, pagination) {
+      if (status === kakao.maps.services.Status.OK) {
+
+        // 정상적으로 검색이 완료됐으면
+        // 검색 목록과 마커를 표출합니다
+        displayPlaces(data);
+
+        // 페이지 번호를 표출합니다
+        displayPagination(pagination);
+
+      } else if (status === kakao.maps.services.Status.ZERO_RESULT) {
+
+        alert('검색 결과가 존재하지 않습니다.');
+        return;
+
+      } else if (status === kakao.maps.services.Status.ERROR) {
+
+        alert('검색 결과 중 오류가 발생했습니다.');
+        return;
+
+      }
+    }
+
+    // 검색 결과 목록과 마커를 표출하는 함수입니다
+    function displayPlaces(places) {
+
+      var listEl = document.getElementById('placesList'),
+        menuEl = document.getElementById('menu_wrap'),
+        fragment = document.createDocumentFragment(),
+        bounds = new kakao.maps.LatLngBounds();
+
+      // 검색 결과 목록에 추가된 항목들을 제거합니다
+      removeAllChildNods(listEl);
+
+      // 지도에 표시되고 있는 마커를 제거합니다
+      removeMarker();
+
+      for (var i = 0; i < places.length; i++) {
+
+        // 마커를 생성하고 지도에 표시합니다
+        var placePosition = new kakao.maps.LatLng(places[i].y, places[i].x),
+          marker = addMarker(placePosition, i),
+          itemEl = getListItem(i, places[i]); // 검색 결과 항목 Element를 생성합니다
+
+        // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
+        // LatLngBounds 객체에 좌표를 추가합니다
+        bounds.extend(placePosition);
+
+        // 마커와 검색결과 항목에 mouseover 했을때
+        // 해당 장소에 인포윈도우에 장소명을 표시합니다
+        // mouseout 했을 때는 인포윈도우를 닫습니다
+        (function(marker, title) {
+          kakao.maps.event.addListener(marker, 'mouseover', function() {
+            displayInfowindow(marker, title);
+          });
+
+          kakao.maps.event.addListener(marker, 'mouseout', function() {
+            infowindow.close();
+          });
+
+          itemEl.onmouseover = function () {
+            displayInfowindow(marker, title);
+          };
+
+          itemEl.onmouseout = function () {
+            infowindow.close();
+          };
+        })(marker, places[i].place_name);
+
+        fragment.appendChild(itemEl);
+      }
+
+      // 검색결과 항목들을 검색결과 목록 Element에 추가합니다
+      listEl.appendChild(fragment);
+      menuEl.scrollTop = 0;
+
+      // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+      map.setBounds(bounds);
+    }
+
+    // 검색결과 항목을 Element로 반환하는 함수입니다
+    function getListItem(index, places) {
+
+      var el = document.createElement('li'),
+        itemStr = '<span class="markerbg marker_' + (index + 1) + '"></span>' +
+              '<div class="info">' +
+              '   <h5>' + places.place_name + '</h5>';
+
+      if (places.road_address_name) {
+        itemStr += '    <span>' + places.road_address_name + '</span>' +
+                  '   <span class="jibun gray">' + places.address_name + '</span>';
+      } else {
+        itemStr += '    <span>' + places.address_name + '</span>';
+      }
+
+      itemStr += '  <span class="tel">' + places.phone + '</span>' +
+              '</div>';
+
+      el.innerHTML = itemStr;
+      el.className = 'item';
+
+      return el;
+    }
+
+    // 마커를 생성하고 지도 위에 마커를 표시하는 함수입니다
+    function addMarker(position, idx) {
+      var imageSrc = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png', // 마커 이미지 url, 스프라이트 이미지를 씁니다
+        imageSize = new kakao.maps.Size(36, 37), // 마커 이미지의 크기
+        imgOptions = {
+          spriteSize: new kakao.maps.Size(36, 691), // 스프라이트 이미지의 크기
+          spriteOrigin: new kakao.maps.Point(0, (idx * 46) + 10), // 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
+          offset: new kakao.maps.Point(13, 37), // 마커 좌표에 일치시킬 이미지 내에서의 좌표
+        },
+        markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imgOptions),
+        marker = new kakao.maps.Marker({
+          position: position, // 마커의 위치
+          image: markerImage,
+        });
+
+      marker.setMap(map); // 지도 위에 마커를 표출합니다
+      markers.push(marker); // 배열에 생성된 마커를 추가합니다
+
+      return marker;
+    }
+
+    // 지도 위에 표시되고 있는 마커를 모두 제거합니다
+    function removeMarker() {
+      for (var i = 0; i < markers.length; i++) {
+        markers[i].setMap(null);
+      }
+      markers = [];
+    }
+
+    // 검색결과 목록 하단에 페이지번호를 표시는 함수입니다
+    function displayPagination(pagination) {
+      var paginationEl = document.getElementById('pagination'),
+        fragment = document.createDocumentFragment(),
+        i;
+
+      // 기존에 추가된 페이지번호를 삭제합니다
+      while (paginationEl.hasChildNodes()) {
+        paginationEl.removeChild(paginationEl.lastChild);
+      }
+
+      for (i = 1; i <= pagination.last; i++) {
+        var el = document.createElement('a');
+        el.href = "#";
+        el.innerHTML = i;
+
+        if (i === pagination.current) {
+          el.className = 'on';
+        } else {
+          el.onclick = (function(i) {
+            return function() {
+              pagination.gotoPage(i);
+            }
+          })(i);
+        }
+
+        fragment.appendChild(el);
+      }
+      paginationEl.appendChild(fragment);
+    }
+
+    // 검색결과 목록 또는 마커를 클릭했을 때 호출되는 함수입니다
+    // 인포윈도우에 장소명을 표시합니다
+    function displayInfowindow(marker, title) {
+      var content = '<div style="padding:5px;z-index:1;">' + title + '</div>';
+
+      infowindow.setContent(content);
+      infowindow.open(map, marker);
+    }
+
+    // 검색결과 목록의 자식 Element를 제거하는 함수입니다
+    function removeAllChildNods(el) {
+      while (el.hasChildNodes()) {
+        el.removeChild(el.lastChild);
+      }
+    }
+  });
+
+  return (
+    <>
+      <div className="map_wrap">
+        <div id="menu_wrap" className="bg_white">
+          <div className="option">
+            <div>
+              <form onSubmit={() => {
+                return false
+              }}>
+                      키워드 : <input
+                  type="text"
+                  value={name}
+                  id="keyword"
+                  size="15"
+                  readOnly
+                />
+                <MapContainer
+                  keyword={name}
+                />
+              </form>
+            </div>
+          </div>
+
+          <PlacesList id="placesList"></PlacesList>
+          <div id="pagination"></div>
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## 해시태그 다중선택시 해당하는 가게목록 보여주기

### Finished
👉🏻 사용자는 가게이름으로 지도를 자동검색할 수 있습니다.

### ToDoNext
/map/가게이름 페이지에서 가게이름 누르면 카카오맵 url 연결되게 하기

(reminder)
지금은 상황>지역>분류 순서대로 눌러야 가게목록 솔팅되는데
순서 상관없이 태그 누르면 가게목록 솔팅돼서 나오게하기
그리고 태그 이중클릭하면 솔팅취소하고 색상빼기