### PR TITLE
[220221] Select tags, then there will be sorted for restaurants

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -11,6 +11,31 @@ import App from './App';
 jest.mock('react-redux');
 
 describe('App', () => {
+  const restaurants = [
+    {
+      "id": "10",
+      "name": "더다이닝랩",
+      "situation": "소개팅",
+      "age": "20대",
+      "place": "홍대/합정",
+      "category": "양식",
+      "priceRange": "3만원 이하",
+      "mood": "none",
+      "2nd-course": "none",
+    },
+    {
+      "id": "36",
+      "name": "보이어",
+      "situation": "데이트",
+      "age": "20대",
+      "place": "성수",
+      "category": "양식",
+      "priceRange": "3만원 이하",
+      "mood": "고급스러운",
+      "2nd-course": "none",
+    },
+  ];
+
   const dispatch = jest.fn();
 
   beforeEach(() => {
@@ -32,7 +57,8 @@ describe('App', () => {
           "mood": "none",
           "2nd-course": "none",
         },
-      ]));
+      ]
+    ));
   });
 
   const renderApp = ({ path }) => render((

--- a/src/actions.js
+++ b/src/actions.js
@@ -88,6 +88,7 @@ export function setCategoryFilter(categoryValue) {
     const {
       restaurantsData,
       placeRestaurantsData,
+      filteredRestaurantsData,
     } = getState();
 
     function filterFromBase(restaurantsData, categoryValue) {
@@ -102,15 +103,16 @@ export function setCategoryFilter(categoryValue) {
       return result
     }
 
-    function previously(restaurantsData, placeRestaurantsData, categoryValue) {
-      if (placeRestaurantsData.length === 0) { // 기존에 장소기준으로 솔팅된게 없다면?
+    function previously(restaurantsData, placeRestaurantsData, filteredRestaurantsData, categoryValue) {
+      if (placeRestaurantsData.length === 0 &&
+        filteredRestaurantsData.length === 0) { // 기존에 장소기준으로 솔팅된게 없다면?
         return filterFromBase(restaurantsData, categoryValue)
       } else {
         return filterFromPlaceSorted(placeRestaurantsData, categoryValue)
       }
     }
 
-    const filteredRestaurantsByCategory = previously(restaurantsData, placeRestaurantsData, categoryValue);
+    const filteredRestaurantsByCategory = previously(restaurantsData, placeRestaurantsData, filteredRestaurantsData, categoryValue);
 
     dispatch(filterRestaurantsByCategory(filteredRestaurantsByCategory, categoryValue))
   }
@@ -122,6 +124,7 @@ export function setPlaceFilter(placeValue) {
     const {
       restaurantsData,
       categoryRestaurantsData,
+      filteredRestaurantsData,
     } = getState();
 
     function filterFromBase(restaurantsData, placeValue) {
@@ -136,15 +139,16 @@ export function setPlaceFilter(placeValue) {
       return result
     }
 
-    function previously(restaurantsData, categoryRestaurantsData, placeValue) {
-      if (categoryRestaurantsData.length === 0) { // 기존에 음식기준으로 솔팅된게 없다면?
+    function previously(restaurantsData, categoryRestaurantsData, filteredRestaurantsData, placeValue) {
+      if (categoryRestaurantsData.length === 0 &&
+        filteredRestaurantsData.length === 0) { // 기존에 음식기준으로 솔팅된게 없다면?
         return filterFromBase(restaurantsData, placeValue)
       } else {
         return filterFromCategorySorted(categoryRestaurantsData, placeValue)
       }
     }
 
-    const filteredRestaurantsByPlace = previously(restaurantsData, categoryRestaurantsData, placeValue);
+    const filteredRestaurantsByPlace = previously(restaurantsData, categoryRestaurantsData, filteredRestaurantsData, placeValue);
 
     dispatch(filterRestaurantsByPlace(filteredRestaurantsByPlace, placeValue))
   }

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,14 +6,6 @@ export function setRestaurants(restaurants) {
   }
 }
 
-// 1. 상황별 솔팅 => 숫자로 필터된 restaurants로 레스토랑 업데이트
-export function filterRestaurantsBySituation(filteredRestaurantsBySituation, sortNumber) {
-  return {
-    type: 'filterRestaurantsBySituation',
-    payload: { filteredRestaurantsBySituation, sortNumber },
-  }
-}
-
 // 2. 상황별 솔팅 => 필터링된 레스토랑 셋!
 export function setSituationRestaurants(restaurantsData) {
   return {
@@ -22,7 +14,15 @@ export function setSituationRestaurants(restaurantsData) {
   }
 }
 
-// 1. 음식종류별 솔팅 => 음식으로 필터된 restaurants로 레스토랑 업데이트
+// 1. 상황별 솔팅 => 숫자로 필터된 레스토랑으로 업데이트
+export function filterRestaurantsBySituation(filteredRestaurantsBySituation, sortNumber) {
+  return {
+    type: 'filterRestaurantsBySituation',
+    payload: { filteredRestaurantsBySituation, sortNumber },
+  }
+}
+
+// 음식종류별 솔팅 => 음식으로 필터된 레스토랑으로 업데이트
 export function filterRestaurantsByCategory(filteredRestaurantsByCategory, categoryValue) {
   return {
     type: 'filterRestaurantsByCategory',
@@ -30,7 +30,7 @@ export function filterRestaurantsByCategory(filteredRestaurantsByCategory, categ
   }
 }
 
-// 1. 장소종류별 솔팅 => 장소로 필터된 restaurants로 레스토랑 업데이트
+// 장소종류별 솔팅 => 장소로 필터된 레스토랑으로 업데이트
 export function filterRestaurantsByPlace(filteredRestaurantsByPlace, placeValue) {
   return {
     type: 'filterRestaurantsByPlace',
@@ -47,7 +47,7 @@ export function setRestaurantName({ value }) {
 
 // <--- Redux Thunk --->
 
-// SituationSelectContainer: 상황별 필터
+// 상황별 필터
 export function setSituationFilter(sortNumber) {
   return (dispatch, getState) => {
     const {
@@ -82,7 +82,7 @@ export function setSituationFilter(sortNumber) {
   };
 }
 
-// CustomFilterContainer: 지역클릭 후 > 음식클릭
+// 음식별 필터
 export function setCategoryFilter(categoryValue) {
   return (dispatch, getState) => {
     const {
@@ -92,33 +92,41 @@ export function setCategoryFilter(categoryValue) {
     } = getState();
 
     function filterFromBase(restaurantsData, categoryValue) {
-      const filteredByCategory = restaurantsData.filter(restaurant => restaurant.category.includes(categoryValue));
+      const filteredByCategory = restaurantsData.filter(restaurant =>
+        restaurant.category.includes(categoryValue));
       const result = [...filteredByCategory];
       return result
     }
 
     function filterFromPlaceSorted(placeRestaurantsData, categoryValue) {
-      const filteredByCategory = placeRestaurantsData.filter(restaurant => restaurant.category.includes(categoryValue));
+      const filteredByCategory = placeRestaurantsData.filter(restaurant =>
+        restaurant.category.includes(categoryValue));
       const result = [...filteredByCategory];
       return result
     }
 
-    function previously(restaurantsData, placeRestaurantsData, filteredRestaurantsData, categoryValue) {
-      if (placeRestaurantsData.length === 0 &&
-        filteredRestaurantsData.length === 0) { // 기존에 장소기준으로 솔팅된게 없다면?
+    function previously(
+      restaurantsData, placeRestaurantsData, filteredRestaurantsData, categoryValue,
+    ) {
+      if (
+        placeRestaurantsData.length === 0 &&
+        filteredRestaurantsData.length === 0
+      ) { // 기존에 장소기준으로 솔팅된게 없다면?
         return filterFromBase(restaurantsData, categoryValue)
       } else {
         return filterFromPlaceSorted(placeRestaurantsData, categoryValue)
       }
     }
 
-    const filteredRestaurantsByCategory = previously(restaurantsData, placeRestaurantsData, filteredRestaurantsData, categoryValue);
+    const filteredRestaurantsByCategory = previously(
+      restaurantsData, placeRestaurantsData, filteredRestaurantsData, categoryValue,
+    );
 
     dispatch(filterRestaurantsByCategory(filteredRestaurantsByCategory, categoryValue))
   }
 }
 
-// CustomFilterContainer: 음식클릭 후 > 지역클릭
+// 장소별 필터
 export function setPlaceFilter(placeValue) {
   return (dispatch, getState) => {
     const {
@@ -128,27 +136,35 @@ export function setPlaceFilter(placeValue) {
     } = getState();
 
     function filterFromBase(restaurantsData, placeValue) {
-      const filteredByPlace = restaurantsData.filter(restaurant => restaurant.place.includes(placeValue));
+      const filteredByPlace = restaurantsData.filter(restaurant =>
+        restaurant.place.includes(placeValue));
       const result = [...filteredByPlace];
       return result
     }
 
     function filterFromCategorySorted(categoryRestaurantsData, placeValue) {
-      const filteredByPlace = categoryRestaurantsData.filter(restaurant => restaurant.place.includes(placeValue));
+      const filteredByPlace = categoryRestaurantsData.filter(restaurant =>
+        restaurant.place.includes(placeValue));
       const result = [...filteredByPlace];
       return result
     }
 
-    function previously(restaurantsData, categoryRestaurantsData, filteredRestaurantsData, placeValue) {
-      if (categoryRestaurantsData.length === 0 &&
-        filteredRestaurantsData.length === 0) { // 기존에 음식기준으로 솔팅된게 없다면?
+    function previously(
+      restaurantsData, categoryRestaurantsData, filteredRestaurantsData, placeValue,
+    ) {
+      if (
+        categoryRestaurantsData.length === 0 &&
+        filteredRestaurantsData.length === 0
+      ) { // 기존에 음식기준으로 솔팅된게 없다면?
         return filterFromBase(restaurantsData, placeValue)
       } else {
         return filterFromCategorySorted(categoryRestaurantsData, placeValue)
       }
     }
 
-    const filteredRestaurantsByPlace = previously(restaurantsData, categoryRestaurantsData, filteredRestaurantsData, placeValue);
+    const filteredRestaurantsByPlace = previously(
+      restaurantsData, categoryRestaurantsData, filteredRestaurantsData, placeValue,
+    );
 
     dispatch(filterRestaurantsByPlace(filteredRestaurantsByPlace, placeValue))
   }

--- a/src/containers/custom/CustomFilterContainer.jsx
+++ b/src/containers/custom/CustomFilterContainer.jsx
@@ -23,7 +23,6 @@ const Buttons = styled.button({
 export default function CustomFilterContainer() {
   const dispatch = useDispatch();
 
-
   // 클릭한 음식종류 이름 받아서 솔팅
   function handleClickCategory(categoryValue) {
     dispatch(setCategoryFilter(categoryValue));
@@ -34,16 +33,21 @@ export default function CustomFilterContainer() {
     dispatch(setPlaceFilter(placeValue));
   }
 
+  const selectedCategory = useSelector((state) =>
+    (state.selectedCategory));
+  const selectedPlace = useSelector((state) =>
+    (state.selectedPlace));
+  const categoryColor = useSelector((state) =>
+    (state.categoryColor));
+  const placeColor = useSelector((state) =>
+    (state.placeColor));
+
   // 그려주기용
-  const categoryColor = useSelector((state) => (state.categoryColor));
-  const placeColor = useSelector((state) => (state.placeColor));
-  const selectedCategory = useSelector((state) => (state.selectedCategory));
-  const selectedPlace = useSelector((state) => (state.selectedPlace));
+  const restaurantsData = useSelector((state) =>
+    (state.restaurantsData));
 
-  const restaurantsData = useSelector((state) => (state.restaurantsData));
-
-  const uniqCategories = uniqBy(restaurantsData, 'category'); // 상황별로 솔팅된(혹은 기존) 레스토랑 카테고리기준으로 고유값 솔팅
-  const uniqPlaces = uniqBy(restaurantsData, 'place'); // 상황별로 솔팅된(혹은 기존) 레스토랑 카테고리기준으로 고유값 솔팅
+  const uniqCategories = uniqBy(restaurantsData, 'category');
+  const uniqPlaces = uniqBy(restaurantsData, 'place');
 
   return (
     <>

--- a/src/containers/custom/CustomFilterContainer.jsx
+++ b/src/containers/custom/CustomFilterContainer.jsx
@@ -34,16 +34,12 @@ export default function CustomFilterContainer() {
     dispatch(setPlaceFilter(placeValue));
   }
 
+  // 그려주기용
   const categoryColor = useSelector((state) => (state.categoryColor));
   const placeColor = useSelector((state) => (state.placeColor));
   const selectedCategory = useSelector((state) => (state.selectedCategory));
   const selectedPlace = useSelector((state) => (state.selectedPlace));
 
-  // 확인용
-  /* const filteredRestaurantsData = useSelector((state) => (state.filteredRestaurantsData));
-  console.log(filteredRestaurantsData) */
-
-  // 그려주기용
   const restaurantsData = useSelector((state) => (state.restaurantsData));
 
   const uniqCategories = uniqBy(restaurantsData, 'category'); // 상황별로 솔팅된(혹은 기존) 레스토랑 카테고리기준으로 고유값 솔팅

--- a/src/containers/custom/CustomFilterContainer.test.jsx
+++ b/src/containers/custom/CustomFilterContainer.test.jsx
@@ -2,6 +2,8 @@ import { render, fireEvent } from '@testing-library/react';
 
 import context from 'jest-plugin-context';
 
+import uniqBy from 'lodash.uniqby';
+
 import { useSelector, useDispatch } from 'react-redux';
 
 import {
@@ -13,9 +15,11 @@ import CustomFilterContainer from './CustomFilterContainer';
 jest.mock('react-redux');
 
 describe('CustomFilterContainer', () => {
+  const mock = jest.fn();
   const dispatch = jest.fn();
 
   beforeEach(() => {
+    mock.mockClear();
     dispatch.mockClear();
 
     useDispatch.mockImplementation(() => dispatch);
@@ -126,7 +130,76 @@ describe('CustomFilterContainer', () => {
     </MemoryRouter>
   ));
 
-  // ToDo 좀 더 디테일하게 리팩터링
+  describe('map', () => {
+    const restaurantsData = [
+      {
+        "id": "10",
+        "name": "더다이닝랩",
+        "situation": "소개팅",
+        "age": "20대",
+        "place": "홍대/합정",
+        "category": "양식",
+        "priceRange": "3만원 이하",
+        "mood": "none",
+        "2nd-course": "none",
+      },
+      {
+        "id": "36",
+        "name": "보이어",
+        "situation": "데이트",
+        "age": "20대",
+        "place": "성수",
+        "category": "양식",
+        "priceRange": "3만원 이하",
+        "mood": "고급스러운",
+        "2nd-course": "none",
+      },
+      {
+        "id": "21",
+        "name": "갈리나데이지",
+        "situation": "썸",
+        "age": "20대",
+        "place": "광화문/종로",
+        "category": "이탈리안",
+        "priceRange": "3만원 이하",
+        "mood": "고급스러운",
+        "2nd-course": "none",
+      },
+      {
+        "id": "17",
+        "name": "고가빈커리하우스",
+        "situation": "소개팅",
+        "age": "30대",
+        "place": "광화문/종로",
+        "category": "인도음식",
+        "priceRange": "3만원 이하",
+        "mood": "캐주얼한",
+        "2nd-course": "none",
+      },
+    ]
+
+    const uniqCategories = uniqBy(restaurantsData, 'category');
+    const uniqPlaces = uniqBy(restaurantsData, 'place');
+
+    it('calls its argument with a non-null argument (1)', () => {
+      const { container } = renderCustomFilterContainer();
+
+      expect(container).toHaveTextContent('무엇을 드시고 싶으세요?');
+
+      uniqCategories.map(category => mock(category))
+      expect(mock).toBeCalled();
+    });
+
+    it('calls its argument with a non-null argument (2)', () => {
+      const { container } = renderCustomFilterContainer();
+
+      expect(container).toHaveTextContent('어디로 가고 싶나요?');
+
+      uniqPlaces.map(place => mock(place))
+      expect(mock).toBeCalled();
+    });
+  });
+
   context('when click "#양식" tag', () => {
     it('calls dispatch with action : setCategoryFilter', () => {
       const { getByText } = renderCustomFilterContainer();

--- a/src/containers/custom/CustomRestaurantsContainer.jsx
+++ b/src/containers/custom/CustomRestaurantsContainer.jsx
@@ -6,15 +6,14 @@ import { useSelector } from 'react-redux';
 
 import { Link } from 'react-router-dom';
 
-const Title = styled.h2({
-  textAlign: 'left',
-  marginBottom: '24px',
-});
-
-const RestaurantsBox = styled.div({
+const Container = styled.div({
   display: 'flex',
   flexDirection: 'column',
   width: '50%',
+  '& h2': {
+    textAlign: 'left',
+    marginBottom: '24px',
+  },
   '& h4': {
     textAlign: 'left',
     marginLeft: '36px',
@@ -22,36 +21,40 @@ const RestaurantsBox = styled.div({
   },
 });
 
-const Restaurant = styled.li({
+const RestaurantsList = styled.li({
   color: '#000',
   fontSize: '24px',
 });
 
 export default function CustomRestaurantsContainer() {
-  const sortedRestaurantsByCategory = useSelector((state) => (
-    state.sortedRestaurantsByCategory === null ?
-      state : state.sortedRestaurantsByCategory
-  ));
-  const uniqRestaurants = uniqBy(sortedRestaurantsByCategory, 'name');
+  const filteredRestaurantsData = useSelector((state) => (state.filteredRestaurantsData));
+  const alert = useSelector((state) => (state.alert));
+
+  console.log(filteredRestaurantsData)
+  console.log(alert)
+
+  const uniqRestaurants = uniqBy(filteredRestaurantsData, 'name');
 
   return (
     <>
-      <RestaurantsBox>
-        <Title>👉🏻 가게이름</Title>
-        {uniqRestaurants.length === 0
+      <Container>
+        <h2>👉🏻 가게이름</h2>
+        {alert
           ?
-          <h4>결과가 없어요 ! 😥</h4>
+          <h4>{alert}</h4>
           :
-          uniqRestaurants.map((obj) => (
-            <ul key={obj.id}>
-              <Link to={`/map/${obj.name}`}
+          uniqRestaurants.map((restaurant) => (
+            <ul key={restaurant.id}>
+              <Link to={`/map/${restaurant.name}`}
               >
-                <Restaurant>{obj.name}</Restaurant>
+                <RestaurantsList>
+                  {restaurant.name}
+                </RestaurantsList>
               </Link>
             </ul>
           ))
         }
-      </RestaurantsBox>
+      </Container>
     </>
   )
 }

--- a/src/containers/custom/CustomRestaurantsContainer.jsx
+++ b/src/containers/custom/CustomRestaurantsContainer.jsx
@@ -27,34 +27,37 @@ const RestaurantsList = styled.li({
 });
 
 export default function CustomRestaurantsContainer() {
-  const filteredRestaurantsData = useSelector((state) => (state.filteredRestaurantsData));
-  const alert = useSelector((state) => (state.alert));
+  const categoryRestaurantsData = useSelector((state) =>
+    (state.categoryRestaurantsData));
+  const placeRestaurantsData = useSelector((state) =>
+    (state.placeRestaurantsData));
+  const filteredRestaurantsData = useSelector((state) =>
+    (state.filteredRestaurantsData));
+  const alert = useSelector((state) =>
+    (state.alert));
 
+  console.log(categoryRestaurantsData)
+  console.log(placeRestaurantsData)
   console.log(filteredRestaurantsData)
   console.log(alert)
 
   const uniqRestaurants = uniqBy(filteredRestaurantsData, 'name');
 
   return (
-    <>
-      <Container>
-        <h2>👉🏻 가게이름</h2>
-        {alert
-          ?
-          <h4>{alert}</h4>
-          :
-          uniqRestaurants.map((restaurant) => (
-            <ul key={restaurant.id}>
-              <Link to={`/map/${restaurant.name}`}
-              >
-                <RestaurantsList>
-                  {restaurant.name}
-                </RestaurantsList>
-              </Link>
-            </ul>
-          ))
-        }
-      </Container>
-    </>
+    <Container>
+      <h2>👉🏻 가게이름</h2>
+      {
+        uniqRestaurants.map((restaurant) => (
+          <ul key={restaurant.id}>
+            <Link to={`/map/${restaurant.name}`}
+            >
+              <RestaurantsList>
+                {restaurant.name}
+              </RestaurantsList>
+            </Link>
+          </ul>
+        ))
+      }
+    </Container>
   )
 }

--- a/src/containers/custom/CustomRestaurantsContainer.test.jsx
+++ b/src/containers/custom/CustomRestaurantsContainer.test.jsx
@@ -1,5 +1,9 @@
 import { render } from '@testing-library/react';
 
+import uniqBy from 'lodash.uniqby';
+
+import { useSelector } from 'react-redux';
+
 import {
   MemoryRouter,
 } from 'react-router-dom';
@@ -7,6 +11,33 @@ import {
 import CustomRestaurantsContainer from './CustomRestaurantsContainer';
 
 describe('CustomRestaurantsContainer', () => {
+  const mock = jest.fn();
+  // const dispatch = jest.fn();
+
+  beforeEach(() => {
+    mock.mockClear();
+    /* dispatch.mockClear();
+
+    useDispatch.mockImplementation(() => dispatch); */
+
+    useSelector.mockImplementation((selector) => (
+      selector.filteredRestaurantsData = [
+        {
+          "id": "10",
+          "name": "더다이닝랩",
+          "situation": "소개팅",
+          "age": "20대",
+          "place": "홍대/합정",
+          "category": "양식",
+          "priceRange": "3만원 이하",
+          "mood": "none",
+          "2nd-course": "none",
+        },
+      ],
+      selector.alert = ''
+    ));
+  });
+
   const renderCustomRestaurantsContainer = () => render((
     <MemoryRouter>
       <CustomRestaurantsContainer
@@ -14,9 +45,42 @@ describe('CustomRestaurantsContainer', () => {
     </MemoryRouter>
   ));
 
-  it('calls dispatch with action : setRestaurants', () => {
-    const { container } = renderCustomRestaurantsContainer();
+  describe('map', () => {
+    const filteredRestaurantsData = [
+      {
+        "id": "10",
+        "name": "더다이닝랩",
+        "situation": "소개팅",
+        "age": "20대",
+        "place": "홍대/합정",
+        "category": "양식",
+        "priceRange": "3만원 이하",
+        "mood": "none",
+        "2nd-course": "none",
+      },
+    ];
+    const uniqRestaurants = uniqBy(filteredRestaurantsData, 'name');
 
-    expect(container).toHaveTextContent('가게이름');
+
+    it('calls its argument with a non-null argument', () => {
+      const { container } = renderCustomRestaurantsContainer();
+
+      expect(container).toHaveTextContent('가게이름');
+
+      uniqRestaurants.map(restaurant => mock(restaurant))
+      expect(mock).toBeCalledWith(
+        {
+          "id": "10",
+          "name": "더다이닝랩",
+          "situation": "소개팅",
+          "age": "20대",
+          "place": "홍대/합정",
+          "category": "양식",
+          "priceRange": "3만원 이하",
+          "mood": "none",
+          "2nd-course": "none",
+        },
+      );
+    });
   });
 });

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -63,39 +63,33 @@ const reducers = {
   // 1. 음식종류별 솔팅 => 장소 > 음식으로 필터된 restaurants로 레스토랑 업데이트
   filterRestaurantsByCategory(state, { payload: { filteredRestaurantsByCategory, categoryValue } }) {
     const {
-      restaurantsData, selectedCategory, selectedPlace, placeRestaurantsData, filteredRestaurantsData,
+      restaurantsData, selectedCategory,
+      filteredRestaurantsData,
+      placeRestaurantsData,
+      categoryRestaurantsData,
     } = state;
 
-    // 똑같은거 중복선택
-    if (selectedCategory === categoryValue) {
+    if (selectedCategory === categoryValue && // 음식 똑같은거 중복선택
+      filteredRestaurantsData.length === categoryRestaurantsData.length) {
       return {
         ...state,
-        placeRestaurantsData: restaurantsData.filter(restaurant => restaurant.place.includes(selectedPlace)), // 원래데이터
         categoryRestaurantsData: [],
-        filteredRestaurantsData: restaurantsData.filter(restaurant => restaurant.place.includes(selectedPlace)),
-        categoryColor: '', // 색없어짐
+        filteredRestaurantsData: placeRestaurantsData,
         selectedCategory: categoryValue,
+        categoryColor: '',
         alert: '',
       }
-    } else if (
-      selectedCategory !== categoryValue
-      && placeRestaurantsData.length !== filteredRestaurantsData.length) { // 카테고리내에서 다른거선택할때
+    } else if (selectedCategory !== categoryValue &&
+      filteredRestaurantsByCategory.length === 0) { // 선택한게 빈배열일때
       return {
         ...state,
         categoryRestaurantsData: restaurantsData.filter(restaurant => restaurant.category.includes(categoryValue)), // 원래데이터
         filteredRestaurantsData: restaurantsData.filter(restaurant => restaurant.category.includes(categoryValue)),
-        categoryColor: 'select', // 색있음
-        selectedCategory: categoryValue, // 선택한 키워드 줌
-      }
-    } else if (filteredRestaurantsByCategory.length === 0) { // 선택한게 빈배열일때
-      return {
-        ...state,
-        categoryRestaurantsData: restaurantsData.filter(restaurant => restaurant.category.includes(categoryValue)), // 원래데이터
-        filteredRestaurantsData: restaurantsData.filter(restaurant => restaurant.category.includes(categoryValue)),
+        placeRestaurantsData: [],
         categoryColor: 'select', // 색있음
         selectedCategory: categoryValue, // 선택한 키워드 줌
         selectedPlace: '',
-        alert: '결과가 없어요 ! 😥',
+        alert: '가고 싶으신 곳을 다시 선택해주세요 ! 😥',
       }
     } else { // 위 해당사항이 없을때
       return {
@@ -104,6 +98,7 @@ const reducers = {
         filteredRestaurantsData: filteredRestaurantsByCategory,
         categoryColor: 'select',
         selectedCategory: categoryValue,
+        alert: '',
       }
     }
   },
@@ -111,39 +106,33 @@ const reducers = {
   // 1. 장소종류별 솔팅 => 음식 > 장소로 필터된 restaurants로 레스토랑 업데이트
   filterRestaurantsByPlace(state, { payload: { filteredRestaurantsByPlace, placeValue } }) {
     const {
-      restaurantsData, selectedPlace, selectedCategory, categoryRestaurantsData, filteredRestaurantsData,
+      restaurantsData, selectedPlace,
+      filteredRestaurantsData,
+      categoryRestaurantsData,
+      placeRestaurantsData,
     } = state;
 
-    if (selectedPlace === placeValue // 똑같은거 중복선택
-    ) {
+    if (selectedPlace === placeValue && // 장소 똑같은거 중복선택
+      filteredRestaurantsData.length === placeRestaurantsData.length) {
       return {
         ...state,
-        categoryRestaurantsData: restaurantsData.filter(restaurant => restaurant.category.includes(selectedCategory)), // 원래데이터
         placeRestaurantsData: [],
-        filteredRestaurantsData: restaurantsData.filter(restaurant => restaurant.category.includes(selectedCategory)),
-        placeColor: '', // 색없어짐
+        filteredRestaurantsData: categoryRestaurantsData,
         selectedPlace: placeValue,
+        placeColor: '',
         alert: '',
       }
-    } else if (
-      selectedPlace !== placeValue
-      && categoryRestaurantsData.length !== filteredRestaurantsData.length) { // 장소내에서 다른거선택할때
+    } else if (selectedPlace !== placeValue &&
+      filteredRestaurantsByPlace.length === 0) { // 선택한게 빈배열일때
       return {
         ...state,
         placeRestaurantsData: restaurantsData.filter(restaurant => restaurant.place.includes(placeValue)), // 원래데이터
         filteredRestaurantsData: restaurantsData.filter(restaurant => restaurant.place.includes(placeValue)),
-        placeColor: 'select', // 색있음
-        selectedPlace: placeValue, // 선택한 키워드 줌
-      }
-    } else if (filteredRestaurantsByPlace.length === 0) { // 선택한게 빈배열일때
-      return {
-        ...state,
-        placeRestaurantsData: restaurantsData.filter(restaurant => restaurant.place.includes(placeValue)), // 원래데이터
-        filteredRestaurantsData: restaurantsData.filter(restaurant => restaurant.place.includes(placeValue)),
+        categoryRestaurantsData: [],
         placeColor: 'select', // 색있음
         selectedPlace: placeValue, // 선택한 키워드 줌
         selectedCategory: '',
-        alert: '결과가 없어요 ! 😥',
+        alert: '드시고 싶은 것을 다시 선택해주세요 ! 😥',
       }
     } else { // 위 해당사항이 없을때
       return {
@@ -152,6 +141,7 @@ const reducers = {
         filteredRestaurantsData: filteredRestaurantsByPlace,
         placeColor: 'select',
         selectedPlace: placeValue,
+        alert: '',
       }
     }
   },

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,20 +1,22 @@
 const initialState = {
   restaurants: [], // JSON에서 받아온 최초의 데이터
   situationRestaurantsData: [], // 상황별로 솔팅해서 저장된 레스토랑
-  restaurantsData: [], // 판단해서 저장된 레스토랑
+  restaurantsData: [], // situationRestaurantsData가 공란일 경우 restaurants로 저장
 
   categoryRestaurantsData: [], // 음식 종류별로 솔팅해서 저장된 레스토랑
   placeRestaurantsData: [], // 장소 종류별로 솔팅해서 저장된 레스토랑
   filteredRestaurantsData: [], // 정상적으로 솔팅된 레스토랑 저장
 
-  categoryColor: '',
-  placeColor: '',
   sortNumber: '',
-  value: '',
-  alter: '',
+  color: '',
+
   selectedCategory: '',
   selectedPlace: '',
+  categoryColor: '',
+  placeColor: '',
+  alter: '',
 
+  value: '',
   newId: 100,
   restaurant: {
     id: '',
@@ -31,27 +33,6 @@ const reducers = {
     }
   },
 
-  // 1. 상황별 솔팅 => 상황별 숫자로 필터된 restaurants로 레스토랑 업데이트
-  filterRestaurantsBySituation(state, { payload: { filteredRestaurantsBySituation, sortNumber } }) {
-    const { situationRestaurantsData } = state; // 상황별로 솔팅해서 저장된 레스토랑 불러옴
-
-    if (filteredRestaurantsBySituation.length == situationRestaurantsData.length) {
-      return {
-        ...state,
-        situationRestaurantsData: [],
-        color: '',
-        sortNumber: '',
-      }
-    } else {
-      return {
-        ...state,
-        situationRestaurantsData: filteredRestaurantsBySituation,
-        color: 'select',
-        sortNumber,
-      }
-    }
-  },
-
   // 2. 상황별 솔팅 => 필터링된 레스토랑 셋!
   setSituationRestaurants(state, { payload: { restaurantsData } }) {
     return {
@@ -60,17 +41,39 @@ const reducers = {
     }
   },
 
-  // 1. 음식종류별 솔팅 => 장소 > 음식으로 필터된 restaurants로 레스토랑 업데이트
+  // 1. 상황별 솔팅 => 상황별 숫자로 필터된 레스토랑으로 업데이트
+  filterRestaurantsBySituation(state, { payload: { filteredRestaurantsBySituation, sortNumber } }) {
+    const { situationRestaurantsData } = state;
+
+    if (filteredRestaurantsBySituation.length == situationRestaurantsData.length) {
+      return {
+        ...state,
+        situationRestaurantsData: [],
+        sortNumber: '',
+        color: '',
+      }
+    } else {
+      return {
+        ...state,
+        situationRestaurantsData: filteredRestaurantsBySituation,
+        sortNumber,
+        color: 'select',
+      }
+    }
+  },
+
+  // 음식종류별 솔팅 => 장소 > 음식으로 필터된 레스토랑으로 업데이트
   filterRestaurantsByCategory(state, { payload: { filteredRestaurantsByCategory, categoryValue } }) {
     const {
-      restaurantsData, selectedCategory,
-      filteredRestaurantsData,
-      placeRestaurantsData,
-      categoryRestaurantsData,
+      restaurantsData,
+      categoryRestaurantsData, placeRestaurantsData,
+      selectedCategory,
     } = state;
 
-    if (selectedCategory === categoryValue && // 음식 똑같은거 중복선택
-      filteredRestaurantsData.length === categoryRestaurantsData.length) {
+    if (
+      selectedCategory === categoryValue && // 음식 똑같은거 중복선택
+      filteredRestaurantsByCategory.length === categoryRestaurantsData.length
+    ) {
       return {
         ...state,
         categoryRestaurantsData: [],
@@ -79,15 +82,18 @@ const reducers = {
         categoryColor: '',
         alert: '',
       }
-    } else if (selectedCategory !== categoryValue &&
+    } else if (
+      selectedCategory !== categoryValue &&
       filteredRestaurantsByCategory.length === 0) { // 선택한게 빈배열일때
       return {
         ...state,
-        categoryRestaurantsData: restaurantsData.filter(restaurant => restaurant.category.includes(categoryValue)), // 원래데이터
-        filteredRestaurantsData: restaurantsData.filter(restaurant => restaurant.category.includes(categoryValue)),
+        categoryRestaurantsData: restaurantsData.filter(restaurant =>
+          restaurant.category.includes(categoryValue)),
+        filteredRestaurantsData: restaurantsData.filter(restaurant =>
+          restaurant.category.includes(categoryValue)),
         placeRestaurantsData: [],
-        categoryColor: 'select', // 색있음
-        selectedCategory: categoryValue, // 선택한 키워드 줌
+        selectedCategory: categoryValue,
+        categoryColor: 'select',
         selectedPlace: '',
         alert: '가고 싶으신 곳을 다시 선택해주세요 ! 😥',
       }
@@ -96,24 +102,25 @@ const reducers = {
         ...state,
         categoryRestaurantsData: filteredRestaurantsByCategory,
         filteredRestaurantsData: filteredRestaurantsByCategory,
-        categoryColor: 'select',
         selectedCategory: categoryValue,
+        categoryColor: 'select',
         alert: '',
       }
     }
   },
 
-  // 1. 장소종류별 솔팅 => 음식 > 장소로 필터된 restaurants로 레스토랑 업데이트
+  // 장소종류별 솔팅 => 음식 > 장소로 필터된 레스토랑으로 업데이트
   filterRestaurantsByPlace(state, { payload: { filteredRestaurantsByPlace, placeValue } }) {
     const {
-      restaurantsData, selectedPlace,
-      filteredRestaurantsData,
-      categoryRestaurantsData,
-      placeRestaurantsData,
+      restaurantsData,
+      categoryRestaurantsData, placeRestaurantsData,
+      selectedPlace,
     } = state;
 
-    if (selectedPlace === placeValue && // 장소 똑같은거 중복선택
-      filteredRestaurantsData.length === placeRestaurantsData.length) {
+    if (
+      selectedPlace === placeValue && // 장소 똑같은거 중복선택
+      filteredRestaurantsByPlace.length === placeRestaurantsData.length
+    ) {
       return {
         ...state,
         placeRestaurantsData: [],
@@ -122,15 +129,18 @@ const reducers = {
         placeColor: '',
         alert: '',
       }
-    } else if (selectedPlace !== placeValue &&
+    } else if (
+      selectedPlace !== placeValue &&
       filteredRestaurantsByPlace.length === 0) { // 선택한게 빈배열일때
       return {
         ...state,
-        placeRestaurantsData: restaurantsData.filter(restaurant => restaurant.place.includes(placeValue)), // 원래데이터
-        filteredRestaurantsData: restaurantsData.filter(restaurant => restaurant.place.includes(placeValue)),
+        placeRestaurantsData: restaurantsData.filter(restaurant =>
+          restaurant.place.includes(placeValue)),
+        filteredRestaurantsData: restaurantsData.filter(restaurant =>
+          restaurant.place.includes(placeValue)),
         categoryRestaurantsData: [],
-        placeColor: 'select', // 색있음
-        selectedPlace: placeValue, // 선택한 키워드 줌
+        selectedPlace: placeValue,
+        placeColor: 'select',
         selectedCategory: '',
         alert: '드시고 싶은 것을 다시 선택해주세요 ! 😥',
       }
@@ -139,8 +149,8 @@ const reducers = {
         ...state,
         placeRestaurantsData: filteredRestaurantsByPlace,
         filteredRestaurantsData: filteredRestaurantsByPlace,
-        placeColor: 'select',
         selectedPlace: placeValue,
+        placeColor: 'select',
         alert: '',
       }
     }

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -4,12 +4,13 @@ import {
   setRestaurantName,
   setRestaurants,
   filterRestaurantsBySituation,
+  filterRestaurantsByCategory,
+  filterRestaurantsByPlace,
 } from './actions';
 
 jest.mock('react-redux');
 
 describe('reducer', () => {
-  // 레스토랑 JSON데이터 셋!
   describe('setRestaurants action', () => {
     it('sets restaurants with JSON data', () => {
       const initialState = {
@@ -47,7 +48,28 @@ describe('reducer', () => {
     });
   });
 
-  // 필터된 restaurants로 레스토랑 업데이트
+  describe('setRestaurantName action', () => {
+    it('changes state of restaurantName from "" to "입력값" and update id', () => {
+      const initialState = {
+        newId: 100,
+        restaurant: {
+          id: '',
+          name: '',
+        },
+      }
+
+      const state = reducer(initialState, setRestaurantName({ value: '입력값' }));
+
+      expect(state).toEqual({
+        newId: 101,
+        restaurant: {
+          id: 100,
+          name: '입력값',
+        },
+      });
+    });
+  });
+
   describe('filterRestaurantsBySituation action', () => {
     it('changes state of restaurants with new restaurants', () => {
       const initialState = {
@@ -102,25 +124,111 @@ describe('reducer', () => {
     });
   });
 
-  describe('setRestaurantName action', () => {
-    it('changes state of restaurantName from "" to "입력값" and update id', () => {
+  describe('filterRestaurantsByCategory action', () => {
+    it('changes state of restaurants with new restaurants', () => {
       const initialState = {
-        newId: 100,
-        restaurant: {
-          id: '',
-          name: '',
-        },
-      }
+        restaurantsData: [
+          {
+            "id": "35",
+            "name": "주옥",
+            "situation": "기념일",
+            "age": "20대",
+            "place": "을지로",
+            "category": "한식",
+            "priceRange": "3~5만원",
+            "mood": "고급스러운",
+            "2nd-course": "none",
+          },
+          {
+            "id": "36",
+            "name": "보이어",
+            "situation": "데이트",
+            "age": "20대",
+            "place": "성수",
+            "category": "양식",
+            "priceRange": "3만원 이하",
+            "mood": "고급스러운",
+            "2nd-course": "none",
+          },
+        ],
+        categoryRestaurantsData: [],
+        filteredRestaurantsData: [],
+        categoryColor: '',
+      };
 
-      const state = reducer(initialState, setRestaurantName({ value: '입력값' }));
-
-      expect(state).toEqual({
-        newId: 101,
-        restaurant: {
-          id: 100,
-          name: '입력값',
+      const filteredRestaurantsByCategory = [
+        {
+          "id": "36",
+          "name": "보이어",
+          "situation": "데이트",
+          "age": "20대",
+          "place": "성수",
+          "category": "양식",
+          "priceRange": "3만원 이하",
+          "mood": "고급스러운",
+          "2nd-course": "none",
         },
-      });
+      ];
+
+      const state = reducer(initialState, filterRestaurantsByCategory(filteredRestaurantsByCategory));
+
+      expect(state.categoryRestaurantsData).toHaveLength(1);
+      expect(state.filteredRestaurantsData).toHaveLength(1);
+      expect(state.categoryColor).toBe('select');
+    });
+  });
+
+  describe('filterRestaurantsByPlace action', () => {
+    it('changes state of restaurants with new restaurants', () => {
+      const initialState = {
+        restaurantsData: [
+          {
+            "id": "35",
+            "name": "주옥",
+            "situation": "기념일",
+            "age": "20대",
+            "place": "을지로",
+            "category": "한식",
+            "priceRange": "3~5만원",
+            "mood": "고급스러운",
+            "2nd-course": "none",
+          },
+          {
+            "id": "36",
+            "name": "보이어",
+            "situation": "데이트",
+            "age": "20대",
+            "place": "성수",
+            "category": "양식",
+            "priceRange": "3만원 이하",
+            "mood": "고급스러운",
+            "2nd-course": "none",
+          },
+        ],
+        placeRestaurantsData: [],
+        filteredRestaurantsData: [],
+        placeColor: '',
+      };
+
+      const filteredRestaurantsByPlace = [
+        {
+          "id": "36",
+          "name": "보이어",
+          "situation": "데이트",
+          "age": "20대",
+          "place": "성수",
+          "category": "양식",
+          "priceRange": "3만원 이하",
+          "mood": "고급스러운",
+          "2nd-course": "none",
+        },
+      ];
+
+      const state = reducer(initialState, filterRestaurantsByPlace(filteredRestaurantsByPlace));
+
+      expect(state.placeRestaurantsData).toHaveLength(1);
+      expect(state.filteredRestaurantsData).toHaveLength(1);
+      expect(state.placeColor).toBe('select');
     });
   });
 });


### PR DESCRIPTION
## 기존앱 기능 improve (사용자 위치정보 추가)

### Finished
👉🏻 사용자는 커스텀페이지에서 해시태그로 가게를 솔팅할 수 있습니다.

[커스텀 페이지]
- [x] 같은거 두번클릭하면 솔팅되게하기
- [x] 가게목록 보이게하기


### ToDoNext
[셀렉트 페이지]
- [ ] 디자인 적용

[커스텀 페이지]
- [ ] 디자인 적용

[가게목록 페이지]
- [ ] 페이지이동을 하지 않고 한 페이지에서 레이아웃 쪼개서 보여주기
- [ ] 가게목록에 썸네일, 평점, 가게이름, 음식종류&위치, 분위기 등을 표시해주기
- [ ] 디자인 적용