### PR TITLE
[220223] Apply design to custom page

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/Superduper-India/project-react-6-Superduper-India/issues"
   },
-  "homepage": "https://codesoom.github.io/project-react-6-Superduper-India/",
+  "homepage": "https://superduper-india.codesoom.com/",
   "devDependencies": {
     "@babel/cli": "^7.16.8",
     "@babel/core": "^7.16.12",

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -58,7 +58,7 @@ describe('App', () => {
   it('renders board page path to "/custom"', () => {
     const { container } = renderApp({ path: '/custom' });
 
-    expect(container).toHaveTextContent('어디 갈지 모르겠다구요?');
+    expect(container).toHaveTextContent('선택해주세요 !');
   });
 
   it('renders board page path to "/post"', () => {

--- a/src/containers/custom/CustomCategoryFilterContainer.jsx
+++ b/src/containers/custom/CustomCategoryFilterContainer.jsx
@@ -9,7 +9,19 @@ import {
 } from '../../actions';
 
 const Container = styled.div({
-  marginRight: '24px',
+  height: '50%',
+});
+
+const TitleBox = styled.div({
+  marginBottom: '1rem',
+})
+
+const Alert = styled.div({
+  height: '1rem',
+  '& span': {
+    fontWeight: 'bold',
+    background: 'hsl(200 100% 90%)',
+  },
 });
 
 const Buttons = styled.button({
@@ -19,10 +31,6 @@ const Buttons = styled.button({
 });
 
 export default function CustomCategoryFilterContainer() {
-  const selectedCategory = useSelector((state) =>
-    (state.selectedCategory));
-  const categoryColor = useSelector((state) =>
-    (state.categoryColor));
   const restaurantsData = useSelector((state) =>
     (state.restaurantsData));
 
@@ -34,9 +42,24 @@ export default function CustomCategoryFilterContainer() {
     dispatch(setCategoryFilter(categoryValue));
   }
 
+  const selectedCategory = useSelector((state) =>
+    (state.selectedCategory));
+  const categoryColor = useSelector((state) =>
+    (state.categoryColor));
+  const alert = useSelector((state) =>
+    (state.alert));
+
   return (
     <Container>
-      <p>무엇을 드시고 싶으세요?</p>
+      <TitleBox>
+        <p>무엇을 드시고 싶으세요?</p>
+        <hr />
+        <Alert>
+          <span>
+            {alert === '드시고 싶은 것을 다시 선택해주세요 !' ? alert : ''}
+          </span>
+        </Alert>
+      </TitleBox>
       {uniqCategories.map((category) => (
         <Buttons
           type='button'

--- a/src/containers/custom/CustomPlaceFilterContainer.jsx
+++ b/src/containers/custom/CustomPlaceFilterContainer.jsx
@@ -9,7 +9,19 @@ import {
 } from '../../actions';
 
 const Container = styled.div({
-  marginRight: '24px',
+  height: '50%',
+});
+
+const TitleBox = styled.div({
+  marginBottom: '1rem',
+})
+
+const Alert = styled.div({
+  height: '1rem',
+  '& span': {
+    fontWeight: 'bold',
+    background: 'hsl(200 100% 90%)',
+  },
 });
 
 const Buttons = styled.button({
@@ -19,10 +31,6 @@ const Buttons = styled.button({
 });
 
 export default function CustomPlaceFilterContainer() {
-  const selectedPlace = useSelector((state) =>
-    (state.selectedPlace));
-  const placeColor = useSelector((state) =>
-    (state.placeColor));
   const restaurantsData = useSelector((state) =>
     (state.restaurantsData));
 
@@ -34,9 +42,24 @@ export default function CustomPlaceFilterContainer() {
     dispatch(setPlaceFilter(placeValue));
   }
 
+  const selectedPlace = useSelector((state) =>
+    (state.selectedPlace));
+  const placeColor = useSelector((state) =>
+    (state.placeColor));
+  const alert = useSelector((state) =>
+    (state.alert));
+
   return (
     <Container>
-      <p>어디로 가고 싶나요?</p>
+      <TitleBox>
+        <p>어디로 가고 싶나요?</p>
+        <hr />
+        <Alert>
+          <span>
+            {alert === '가고 싶으신 곳을 다시 선택해주세요 !' ? alert : ''}
+          </span>
+        </Alert>
+      </TitleBox>
       {uniqPlaces.map((place) => (
         <Buttons
           type="button"

--- a/src/containers/custom/CustomRestaurantsContainer.jsx
+++ b/src/containers/custom/CustomRestaurantsContainer.jsx
@@ -9,43 +9,26 @@ import { Link } from 'react-router-dom';
 const Container = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  width: '50%',
-  '& h2': {
-    textAlign: 'left',
-    marginBottom: '24px',
-  },
   '& h4': {
-    textAlign: 'left',
-    marginLeft: '36px',
-    fontSize: '24px',
+    fontWeight: '700',
+    color: '#0E0E0E',
+    marginBottom: '3rem',
   },
 });
 
 const RestaurantsList = styled.li({
   color: '#0E0E0E',
-  fontSize: '24px',
 });
 
 export default function CustomRestaurantsContainer() {
-  const categoryRestaurantsData = useSelector((state) =>
-    (state.categoryRestaurantsData));
-  const placeRestaurantsData = useSelector((state) =>
-    (state.placeRestaurantsData));
   const filteredRestaurantsData = useSelector((state) =>
     (state.filteredRestaurantsData));
-  const alert = useSelector((state) =>
-    (state.alert));
-
-  /* console.log(categoryRestaurantsData)
-  console.log(placeRestaurantsData)
-  console.log(filteredRestaurantsData)
-  console.log(alert) */
 
   const uniqRestaurants = uniqBy(filteredRestaurantsData, 'name');
 
   return (
     <Container>
-      <h2>👉🏻 가게이름</h2>
+      <h4>고객님이 좋아할 음식점 추천</h4>
       {
         uniqRestaurants.map((restaurant) => (
           <ul key={restaurant.id}>

--- a/src/containers/custom/CustomRestaurantsContainer.test.jsx
+++ b/src/containers/custom/CustomRestaurantsContainer.test.jsx
@@ -65,7 +65,7 @@ describe('CustomRestaurantsContainer', () => {
     it('calls its argument with a non-null argument', () => {
       const { container } = renderCustomRestaurantsContainer();
 
-      expect(container).toHaveTextContent('가게이름');
+      expect(container).toHaveTextContent('고객님이 좋아할 음식점 추천');
 
       uniqRestaurants.map(restaurant => mock(restaurant))
       expect(mock).toBeCalledWith(

--- a/src/pages/CustomPage.jsx
+++ b/src/pages/CustomPage.jsx
@@ -1,6 +1,8 @@
 // 관심사: 화면 구성과 레스토랑 저장, 스토어에서 레스토랑 컨테이너에 뿌려주기
 import styled from '@emotion/styled';
 
+import { Link } from 'react-router-dom';
+
 import { useEffect } from 'react';
 
 import { useSelector, useDispatch } from 'react-redux';
@@ -15,16 +17,33 @@ import {
 
 const CustomPageLayout = styled.div({
   display: 'flex',
-  flexDirection: 'column',
-  padding: '48px 36px',
+  height: '100vh',
 });
 
 const TitleBox = styled.div({
-  marginBottom: '36px',
+  display: 'flex',
+  justifyContent: 'flex-start',
+  marginBottom: '3rem',
+  '& h4': {
+    fontWeight: '700',
+    color: '#0E0E0E',
+  },
+  '& span': {
+    marginRight: '0.5rem',
+    color: '#0E0E0E',
+  },
 });
 
-const FormBox = styled.div({
-  display: 'flex',
+const Container = styled.div({
+  padding: '4rem 3rem',
+  width: '50%',
+});
+
+const ResultRestaurants = styled.div({
+  padding: '4rem 3rem',
+  width: '50%',
+  backgroundColor: '#F5F5F5',
+  boxShadow: 'inset 0.5rem 0 5rem rgba(0,0,0,0.05)',
 });
 
 export default function CustomPage({ restaurants }) {
@@ -50,16 +69,30 @@ export default function CustomPage({ restaurants }) {
     dispatch(setRestaurantsData(restaurantsData));
   }, []);
 
+  const filteredRestaurantsData = useSelector((state) =>
+    (state.filteredRestaurantsData));
+
   return (
     <CustomPageLayout>
-      <TitleBox>
-        <h2>어디 갈지 모르겠다구요? 👀</h2>
-      </TitleBox>
-      <FormBox>
+      <Container>
+        <TitleBox>
+          <Link to='/home'>
+            <span className="material-icons">
+              arrow_back
+            </span>
+          </Link>
+          <h4>선택해주세요 !</h4>
+        </TitleBox>
         <CustomCategoryFilterContainer />
         <CustomPlaceFilterContainer />
-        <CustomRestaurantsContainer />
-      </FormBox>
+      </Container>
+      {filteredRestaurantsData.length !== 0 ?
+        <ResultRestaurants>
+          <CustomRestaurantsContainer />
+        </ResultRestaurants> :
+        <ResultRestaurants>
+        </ResultRestaurants>
+      }
     </CustomPageLayout>
   )
 }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -13,7 +13,7 @@ const CustomMenuBox = styled.div({
   display: 'flex',
   flexDirection: 'column',
   flexWrap: 'wrap',
-  padding: '4rem 2rem',
+  padding: '4rem 3rem',
 });
 
 const TitleBox = styled.div({
@@ -35,11 +35,12 @@ const MainBox = styled.div({
   alignItems: 'center',
 });
 
+// ToDo responsive 앱으로 할때 화면 너비에 따라 이미지나오는 갯수 다르게 하기
 const Background = styled.div({
   filter: 'blur(0.5rem) opacity(25%)',
   '& img': {
-    width: '11rem',
-    height: '11rem',
+    width: '10rem',
+    height: '10rem',
     margin: '1rem',
   },
 });

--- a/src/pages/SituationSelectPage.jsx
+++ b/src/pages/SituationSelectPage.jsx
@@ -14,15 +14,15 @@ import {
 const SituationSelectPageLayout = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  padding: '100px 0',
+  margin: '1.5rem 0',
 });
 
 const DecorateCircle = styled.div({
-  position: 'absolute',
-  zIndex: '-1',
   width: '640px',
   height: '640px',
   borderRadius: '320px',
+  position: 'absolute',
+  zIndex: '-1',
   left: '200px',
   top: '-166px',
   backgroundColor: '#F5F5F5',
@@ -33,12 +33,8 @@ const TitleBox = styled.div({
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
-  padding: '0  36px',
   '& h2': {
-    marginBottom: '24px',
-  },
-  '& h4': {
-    paddingBottom: '24px',
+    marginBottom: '1.5rem',
   },
 });
 
@@ -48,7 +44,7 @@ const SelectBox = styled.div({
   alignItems: 'center',
   flexWrap: 'wrap',
   width: '100%',
-  padding: '4rem 2rem',
+  margin: '3rem 0',
 });
 
 const ConfirmBox = styled.div({
@@ -56,7 +52,6 @@ const ConfirmBox = styled.div({
   justifyContent: 'center',
   alignItems: 'center',
   flexWrap: 'wrap',
-  padding: '2rem',
 });
 
 export default function SituationSelectPage({ restaurants }) {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -103,7 +103,7 @@ const reducers = {
         selectedCategory: categoryValue,
         categoryColor: 'select',
         selectedPlace: '',
-        alert: '가고 싶으신 곳을 다시 선택해주세요 ! 😥',
+        alert: '가고 싶으신 곳을 다시 선택해주세요 !',
       }
     } else { // 위 해당사항이 없을때
       return {
@@ -150,7 +150,7 @@ const reducers = {
         selectedPlace: placeValue,
         placeColor: 'select',
         selectedCategory: '',
-        alert: '드시고 싶은 것을 다시 선택해주세요 ! 😥',
+        alert: '드시고 싶은 것을 다시 선택해주세요 !',
       }
     } else { // 위 해당사항이 없을때
       return {


### PR DESCRIPTION
## 기존앱 기능 improve (사용자 위치정보 추가)

### Finished
[커스텀 페이지]
- [x] 디자인 적용
- [x] 페이지이동을 하지 않고 커스텀 페이지에서 레이아웃 쪼개서 가게목록 보여주기

### 결과화면
https://user-images.githubusercontent.com/89244209/155325803-9fc5bb39-a6b0-4075-aca9-7a35bd6c8ea5.mov


### ToDoNext
[커스텀 페이지]
- ‘아무거나’ 선택기능추가
- 검색기능추가
- 가게목록에 썸네일, 평점, 가게이름, 음식종류&위치, 분위기 등을 표시해주기
- 가게목록 디자인 적용